### PR TITLE
Problem: GHSA-86h5-xcpx-cfqc is not merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+* (x/staking) Fix a possible bypass of delagator slashing: [GHSA-86h5-xcpx-cfqc](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-86h5-xcpx-cfqc)
+
 ## [v0.46.16](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.16) - 2023-11-07
 
 EOL notice. This is the last release of the `v0.46.x` line. Per this version, the v0.46.x line reached its end-of-life.

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -264,7 +264,7 @@ func NewSimApp(
 		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.ModuleAccountAddrs(),
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
-		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
+		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName), 0,
 	)
 	app.MintKeeper = mintkeeper.NewKeeper(
 		appCodec, keys[minttypes.StoreKey], app.GetSubspace(minttypes.ModuleName), &stakingKeeper,

--- a/x/auth/migrations/v043/store_test.go
+++ b/x/auth/migrations/v043/store_test.go
@@ -658,6 +658,7 @@ func createValidator(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers i
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
+		0,
 	)
 
 	val1, err := stakingtypes.NewValidator(valAddrs[0], pks[0], stakingtypes.Description{})

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -48,6 +48,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
+		0,
 	)
 
 	val1, err := stakingtypes.NewValidator(valAddrs[0], pks[0], stakingtypes.Description{})

--- a/x/staking/common_test.go
+++ b/x/staking/common_test.go
@@ -49,6 +49,7 @@ func getBaseSimappWithCustomKeeper(t *testing.T) (*codec.LegacyAmino, *simapp.Si
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.GetSubspace(types.ModuleName),
+		0,
 	)
 	app.StakingKeeper.SetParams(ctx, types.DefaultParams())
 

--- a/x/staking/keeper/common_test.go
+++ b/x/staking/keeper/common_test.go
@@ -31,6 +31,7 @@ func createTestInput(t *testing.T) (*codec.LegacyAmino, *simapp.SimApp, sdk.Cont
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.GetSubspace(types.ModuleName),
+		0,
 	)
 	return app.LegacyAmino(), app, ctx
 }

--- a/x/staking/keeper/grpc_query_test.go
+++ b/x/staking/keeper/grpc_query_test.go
@@ -796,6 +796,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.GetSubspace(types.ModuleName),
+		0,
 	)
 
 	val1 := teststaking.NewValidator(t, valAddrs[0], pks[0])

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -27,12 +27,15 @@ type Keeper struct {
 	bankKeeper types.BankKeeper
 	hooks      types.StakingHooks
 	paramstore paramtypes.Subspace
+
+	hardForkHeight int64
 }
 
 // NewKeeper creates a new staking Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key storetypes.StoreKey, ak types.AccountKeeper, bk types.BankKeeper,
 	ps paramtypes.Subspace,
+	hardForkHeight int64,
 ) Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -55,6 +58,8 @@ func NewKeeper(
 		bankKeeper: bk,
 		paramstore: ps,
 		hooks:      nil,
+
+		hardForkHeight: hardForkHeight,
 	}
 }
 

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -255,7 +255,7 @@ func (k Keeper) SlashRedelegation(ctx sdk.Context, srcValidator types.Validator,
 			panic(err)
 		}
 
-		if k.hardForkHeight > ctx.BlockHeight() {
+		if k.hardForkHeight >= ctx.BlockHeight() {
 			// Handle undelegation after redelegation
 			// Prioritize slashing unbondingDelegation than delegation
 			unbondingDelegation, found := k.GetUnbondingDelegation(ctx, sdk.MustAccAddressFromBech32(redelegation.DelegatorAddress), valDstAddr)

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -250,15 +250,54 @@ func (k Keeper) SlashRedelegation(ctx sdk.Context, srcValidator types.Validator,
 		slashAmount := slashAmountDec.TruncateInt()
 		totalSlashAmount = totalSlashAmount.Add(slashAmount)
 
+		valDstAddr, err := sdk.ValAddressFromBech32(redelegation.ValidatorDstAddress)
+		if err != nil {
+			panic(err)
+		}
+
+		if k.hardForkHeight > ctx.BlockHeight() {
+			// Handle undelegation after redelegation
+			// Prioritize slashing unbondingDelegation than delegation
+			unbondingDelegation, found := k.GetUnbondingDelegation(ctx, sdk.MustAccAddressFromBech32(redelegation.DelegatorAddress), valDstAddr)
+			if found {
+				for i, entry := range unbondingDelegation.Entries {
+					// slash with the amount of `slashAmount` if possible, else slash all unbonding token
+					unbondingSlashAmount := math.MinInt(slashAmount, entry.Balance)
+
+					switch {
+					// There's no token to slash
+					case unbondingSlashAmount.IsZero():
+						continue
+					// If unbonding started before this height, stake didn't contribute to infraction
+					case entry.CreationHeight < infractionHeight:
+						continue
+					// Unbonding delegation no longer eligible for slashing, skip it
+					case entry.IsMature(now):
+						continue
+					// Slash the unbonding delegation
+					default:
+						// update remaining slashAmount
+						slashAmount = slashAmount.Sub(unbondingSlashAmount)
+
+						notBondedBurnedAmount = notBondedBurnedAmount.Add(unbondingSlashAmount)
+						entry.Balance = entry.Balance.Sub(unbondingSlashAmount)
+						unbondingDelegation.Entries[i] = entry
+						k.SetUnbondingDelegation(ctx, unbondingDelegation)
+					}
+				}
+			}
+
+			if slashAmount.IsZero() {
+				continue
+			}
+		}
+
+		// Slash the moved delegation
+
 		// Unbond from target validator
 		sharesToUnbond := slashFactor.Mul(entry.SharesDst)
 		if sharesToUnbond.IsZero() {
 			continue
-		}
-
-		valDstAddr, err := sdk.ValAddressFromBech32(redelegation.ValidatorDstAddress)
-		if err != nil {
-			panic(err)
 		}
 
 		delegatorAddress := sdk.MustAccAddressFromBech32(redelegation.DelegatorAddress)


### PR DESCRIPTION
- cherry-pick the fix in a hardfork style.

* fix slashing logic

* add test

* changelog + release notes

* word

---------

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)