### PR TITLE
Problem: block gas wanted not supported in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (bank) [#237](https://github.com/crypto-org-chain/cosmos-sdk/pull/237) Support virtual accounts in sending coins.
 * [#243](https://github.com/crypto-org-chain/cosmos-sdk/pull/243) Support `RunAtomic` API in `Context` to use new CoW branched cache store.
 * [#248](https://github.com/crypto-org-chain/cosmos-sdk/pull/248) Init btree store lazily to save allocations when no content insert into it.
+* [#252](https://github.com/crypto-org-chain/cosmos-sdk/pull/252) Add `BlockGasWanted` to `Context` to support feemarket module.
 
 ## [Unreleased-Upstream]
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -796,13 +796,21 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Request
 		app.finalizeBlockState.ms = app.finalizeBlockState.ms.SetTracingContext(nil).(storetypes.CacheMultiStore)
 	}
 
-	var blockGasUsed uint64
+	var (
+		blockGasUsed   uint64
+		blockGasWanted uint64
+	)
 	for _, res := range txResults {
 		blockGasUsed += uint64(res.GasUsed)
+		blockGasWanted += uint64(res.GasWanted)
 	}
-	sdkCtx := app.finalizeBlockState.Context().WithBlockGasUsed(blockGasUsed)
+	app.finalizeBlockState.SetContext(
+		app.finalizeBlockState.Context().
+			WithBlockGasUsed(blockGasUsed).
+			WithBlockGasWanted(blockGasWanted),
+	)
 
-	endBlock, err := app.endBlock(sdkCtx)
+	endBlock, err := app.endBlock(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -807,7 +807,7 @@ func (app *BaseApp) deliverTxWithMultiStore(tx []byte, txIndex int, txMultiStore
 
 // endBlock is an application-defined function that is called after transactions
 // have been processed in FinalizeBlock.
-func (app *BaseApp) endBlock(ctx context.Context) (sdk.EndBlock, error) {
+func (app *BaseApp) endBlock(_ context.Context) (sdk.EndBlock, error) {
 	var endblock sdk.EndBlock
 
 	if app.endBlocker != nil {

--- a/types/context.go
+++ b/types/context.go
@@ -74,6 +74,8 @@ type Context struct {
 	txCount int
 	// sum the gas used by all the transactions in the current block, only accessible by end blocker
 	blockGasUsed uint64
+	// sum the gas wanted by all the transactions in the current block, only accessible by end blocker
+	blockGasWanted uint64
 }
 
 // Proposed rename, not done to avoid API breakage
@@ -105,6 +107,7 @@ func (c Context) TxIndex() int                                  { return c.txInd
 func (c Context) MsgIndex() int                                 { return c.msgIndex }
 func (c Context) TxCount() int                                  { return c.txCount }
 func (c Context) BlockGasUsed() uint64                          { return c.blockGasUsed }
+func (c Context) BlockGasWanted() uint64                        { return c.blockGasWanted }
 
 // clone the header before returning
 func (c Context) BlockHeader() cmtproto.Header {
@@ -343,6 +346,11 @@ func (c Context) WithMsgIndex(msgIndex int) Context {
 
 func (c Context) WithBlockGasUsed(gasUsed uint64) Context {
 	c.blockGasUsed = gasUsed
+	return c
+}
+
+func (c Context) WithBlockGasWanted(gasWanted uint64) Context {
+	c.blockGasWanted = gasWanted
 	return c
 }
 


### PR DESCRIPTION
Solution:
- support block gas wanted in context directly, so feemarket don't need to recalculate it using transient stores, see: https://github.com/crypto-org-chain/ethermint/pull/451
- fix the way context is updated

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
