### PR TITLE
Problem: automatic signer getter don't support bytes field

### DIFF
--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -31,6 +31,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+* [#276](https://github.com/crypto-org-chain/cosmos-sdk/pull/276) Support bytes in automatic signer getters.
+
 ## v0.13.1
 
 ### Features

--- a/x/tx/internal/testpb/signers.proto
+++ b/x/tx/internal/testpb/signers.proto
@@ -92,7 +92,7 @@ message DeeplyNestedRepeatedSigner {
 
 message BadSigner {
   option (cosmos.msg.v1.signer) = "signer";
-  bytes signer                  = 1;
+  int32 signer                  = 1;
 }
 
 message NoSignerOption {

--- a/x/tx/internal/testpb/signers.pulsar.go
+++ b/x/tx/internal/testpb/signers.pulsar.go
@@ -7900,8 +7900,8 @@ func (x *fastReflection_BadSigner) Interface() protoreflect.ProtoMessage {
 // While iterating, mutating operations may only be performed
 // on the current field descriptor.
 func (x *fastReflection_BadSigner) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
-	if len(x.Signer) != 0 {
-		value := protoreflect.ValueOfBytes(x.Signer)
+	if x.Signer != int32(0) {
+		value := protoreflect.ValueOfInt32(x.Signer)
 		if !f(fd_BadSigner_signer, value) {
 			return
 		}
@@ -7922,7 +7922,7 @@ func (x *fastReflection_BadSigner) Range(f func(protoreflect.FieldDescriptor, pr
 func (x *fastReflection_BadSigner) Has(fd protoreflect.FieldDescriptor) bool {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		return len(x.Signer) != 0
+		return x.Signer != int32(0)
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -7940,7 +7940,7 @@ func (x *fastReflection_BadSigner) Has(fd protoreflect.FieldDescriptor) bool {
 func (x *fastReflection_BadSigner) Clear(fd protoreflect.FieldDescriptor) {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		x.Signer = nil
+		x.Signer = int32(0)
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -7959,7 +7959,7 @@ func (x *fastReflection_BadSigner) Get(descriptor protoreflect.FieldDescriptor) 
 	switch descriptor.FullName() {
 	case "BadSigner.signer":
 		value := x.Signer
-		return protoreflect.ValueOfBytes(value)
+		return protoreflect.ValueOfInt32(value)
 	default:
 		if descriptor.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -7981,7 +7981,7 @@ func (x *fastReflection_BadSigner) Get(descriptor protoreflect.FieldDescriptor) 
 func (x *fastReflection_BadSigner) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		x.Signer = value.Bytes()
+		x.Signer = int32(value.Int())
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -8018,7 +8018,7 @@ func (x *fastReflection_BadSigner) Mutable(fd protoreflect.FieldDescriptor) prot
 func (x *fastReflection_BadSigner) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	switch fd.FullName() {
 	case "BadSigner.signer":
-		return protoreflect.ValueOfBytes(nil)
+		return protoreflect.ValueOfInt32(int32(0))
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: BadSigner"))
@@ -8088,9 +8088,8 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 		var n int
 		var l int
 		_ = l
-		l = len(x.Signer)
-		if l > 0 {
-			n += 1 + l + runtime.Sov(uint64(l))
+		if x.Signer != 0 {
+			n += 1 + runtime.Sov(uint64(x.Signer))
 		}
 		if x.unknownFields != nil {
 			n += len(x.unknownFields)
@@ -8121,12 +8120,10 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 			i -= len(x.unknownFields)
 			copy(dAtA[i:], x.unknownFields)
 		}
-		if len(x.Signer) > 0 {
-			i -= len(x.Signer)
-			copy(dAtA[i:], x.Signer)
-			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Signer)))
+		if x.Signer != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.Signer))
 			i--
-			dAtA[i] = 0xa
+			dAtA[i] = 0x8
 		}
 		if input.Buf != nil {
 			input.Buf = append(input.Buf, dAtA...)
@@ -8178,10 +8175,10 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 			}
 			switch fieldNum {
 			case 1:
-				if wireType != 2 {
+				if wireType != 0 {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Signer", wireType)
 				}
-				var byteLen int
+				x.Signer = 0
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
@@ -8191,26 +8188,11 @@ func (x *fastReflection_BadSigner) ProtoMethods() *protoiface.Methods {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					byteLen |= int(b&0x7F) << shift
+					x.Signer |= int32(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
 				}
-				if byteLen < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				postIndex := iNdEx + byteLen
-				if postIndex < 0 {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
-				}
-				if postIndex > l {
-					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
-				}
-				x.Signer = append(x.Signer[:0], dAtA[iNdEx:postIndex]...)
-				if x.Signer == nil {
-					x.Signer = []byte{}
-				}
-				iNdEx = postIndex
 			default:
 				iNdEx = preIndex
 				skippy, err := runtime.Skip(dAtA[iNdEx:])
@@ -9386,7 +9368,7 @@ type BadSigner struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Signer []byte `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
+	Signer int32 `protobuf:"varint,1,opt,name=signer,proto3" json:"signer,omitempty"`
 }
 
 func (x *BadSigner) Reset() {
@@ -9409,11 +9391,11 @@ func (*BadSigner) Descriptor() ([]byte, []int) {
 	return file_signers_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *BadSigner) GetSigner() []byte {
+func (x *BadSigner) GetSigner() int32 {
 	if x != nil {
 		return x.Signer
 	}
-	return nil
+	return 0
 }
 
 type NoSignerOption struct {
@@ -9885,7 +9867,7 @@ var file_signers_proto_rawDesc = []byte{
 	0x05, 0x69, 0x6e, 0x6e, 0x65, 0x72, 0x3a, 0x0a, 0x82, 0xe7, 0xb0, 0x2a, 0x05, 0x69, 0x6e, 0x6e,
 	0x65, 0x72, 0x3a, 0x0a, 0x82, 0xe7, 0xb0, 0x2a, 0x05, 0x69, 0x6e, 0x6e, 0x65, 0x72, 0x22, 0x30,
 	0x0a, 0x09, 0x42, 0x61, 0x64, 0x53, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x12, 0x16, 0x0a, 0x06, 0x73,
-	0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x06, 0x73, 0x69, 0x67,
+	0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x73, 0x69, 0x67,
 	0x6e, 0x65, 0x72, 0x3a, 0x0b, 0x82, 0xe7, 0xb0, 0x2a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72,
 	0x22, 0x28, 0x0a, 0x0e, 0x4e, 0x6f, 0x53, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x4f, 0x70, 0x74, 0x69,
 	0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01,

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -297,6 +297,12 @@ func (c *Context) makeGetSignersFunc(descriptor protoreflect.MessageDescriptor) 
 				}
 				return arr, nil
 			}
+		case protoreflect.BytesKind:
+			fieldGetters[i] = func(msg proto.Message, arr [][]byte) ([][]byte, error) {
+				addrBz := msg.ProtoReflect().Get(field).Bytes()
+				return append(arr, addrBz), nil
+			}
+
 		default:
 			return nil, fmt.Errorf("unexpected field type %s for field %s in message %s", field.Kind(), fieldName, descriptor.FullName())
 		}


### PR DESCRIPTION
Solution:
- support bytes fields to support MsgEthereumTx

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
