### PR TITLE
Problem: segmentation violation error on simulate runTx

### DIFF
--- a/x/auth/keeper/params.go
+++ b/x/auth/keeper/params.go
@@ -25,6 +25,6 @@ func (ak AccountKeeper) GetParams(ctx sdk.Context) (params types.Params) {
 	if bz == nil {
 		return params
 	}
-	ak.cdc.MustUnmarshal(bz, &params)
+	ak.cdc.MustUnmarshal(bz[:], &params)
 	return params
 }


### PR DESCRIPTION
<Details>
unexpected fault address 0x10bbb0009
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10bbb0009 pc=0x105117b80]

goroutine 2936 gp=0x14002d0da40 m=20 mp=0x14003488008 [running]:
runtime.throw({0x10657fd71?, 0x20?})
	/Users/mavis/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.darwin-arm64/src/runtime/panic.go:1023 +0x40 fp=0x140011c9150 sp=0x140011c9120 pc=0x1042e00e0
runtime.sigpanic()
	/Users/mavis/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.darwin-arm64/src/runtime/signal_unix.go:895 +0x22c fp=0x140011c91b0 sp=0x140011c9150 pc=0x1042fa63c
github.com/cosmos/cosmos-sdk/x/auth/types.(*Params).Unmarshal(0x1400332f6e0, {0x10bbb0009, 0xd, 0x3905})
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/types/auth.pb.go:1070 +0x190 fp=0x140011c9240 sp=0x140011c91c0 pc=0x105117b80
github.com/cosmos/cosmos-sdk/codec.(*ProtoCodec).Unmarshal(0x14000cb3cf0, {0x10bbb0009?, 0x0?, 0x3905?}, {0x1090af810, 0x1400332f6e0})
	/Users/mavis/Documents/crypto/cosmos-sdk/codec/proto_codec.go:92 +0x34 fp=0x140011c9280 sp=0x140011c9240 pc=0x104a59da4
github.com/cosmos/cosmos-sdk/codec.(*ProtoCodec).MustUnmarshal(0x14002e8f800?, {0x10bbb0009?, 0x1?, 0x1?}, {0x1090af810?, 0x1400332f6e0?})
	/Users/mavis/Documents/crypto/cosmos-sdk/codec/proto_codec.go:107 +0x28 fp=0x140011c92c0 sp=0x140011c9280 pc=0x104a59f48
github.com/cosmos/cosmos-sdk/x/auth/keeper.AccountKeeper.GetParams({{_, _}, {_, _}, _, _, {_, _}, {_, _}}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/keeper/params.go:28 +0xe8 fp=0x140011c9590 sp=0x140011c92c0 pc=0x1053c7b78
github.com/cosmos/cosmos-sdk/x/auth/keeper.(*AccountKeeper).GetParams(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...})
	<autogenerated>:1 +0xa4 fp=0x140011c9930 sp=0x140011c9590 pc=0x1053c9254
github.com/cosmos/cosmos-sdk/x/auth/ante.ValidateSigCountDecorator.AnteHandle({{_, _}}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/sigverify.go:369 +0xa4 fp=0x140011ca1c0 sp=0x140011c9930 pc=0x10513a774
github.com/cosmos/cosmos-sdk/x/auth/ante.(*ValidateSigCountDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0xa4 fp=0x140011ca9e0 sp=0x140011ca1c0 pc=0x10513ccc4
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011cb200 sp=0x140011ca9e0 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.SetPubKeyDecorator.AnteHandle({{_, _}}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/sigverify.go:126 +0x868 fp=0x140011cbf50 sp=0x140011cb200 pc=0x105138fa8
github.com/cosmos/cosmos-sdk/x/auth/ante.(*SetPubKeyDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0xa4 fp=0x140011cc770 sp=0x140011cbf50 pc=0x10513c7a4
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011ccf90 sp=0x140011cc770 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.DeductFeeDecorator.AnteHandle({{_, _}, {_, _}, {_, _}, _}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/fee.go:67 +0x280 fp=0x140011cdf90 sp=0x140011ccf90 pc=0x105137150
github.com/cosmos/cosmos-sdk/x/auth/ante.(*DeductFeeDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0xec fp=0x140011ce810 sp=0x140011cdf90 pc=0x10513c52c
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011cf030 sp=0x140011ce810 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.ConsumeTxSizeGasDecorator.AnteHandle({{_, _}}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/basic.go:143 +0x494 fp=0x140011d0110 sp=0x140011cf030 pc=0x1051366d4
github.com/cosmos/cosmos-sdk/x/auth/ante.(*ConsumeTxSizeGasDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0xa4 fp=0x140011d0930 sp=0x140011d0110 pc=0x10513c274
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011d1150 sp=0x140011d0930 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.ValidateMemoDecorator.AnteHandle({{_, _}}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/basic.go:67 +0x15c fp=0x140011d19d0 sp=0x140011d1150 pc=0x10513602c
github.com/cosmos/cosmos-sdk/x/auth/ante.(*ValidateMemoDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0xa4 fp=0x140011d21f0 sp=0x140011d19d0 pc=0x10513c134
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011d2a10 sp=0x140011d21f0 pc=0x104dccee4
github.com/evmos/ethermint/app/ante.MinGasPriceDecorator.AnteHandle({{_, _}, {_, _}}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/ethermint/app/ante/fees.go:91 +0x260 fp=0x140011d3350 sp=0x140011d2a10 pc=0x105ee9360
github.com/evmos/ethermint/app/ante.(*MinGasPriceDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0xb4 fp=0x140011d3b80 sp=0x140011d3350 pc=0x105eedec4
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011d43a0 sp=0x140011d3b80 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.TxTimeoutHeightDecorator.AnteHandle({}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/basic.go:206 +0x20c fp=0x140011d5100 sp=0x140011d43a0 pc=0x105136b0c
github.com/cosmos/cosmos-sdk/x/auth/ante.(*TxTimeoutHeightDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0x94 fp=0x140011d5910 sp=0x140011d5100 pc=0x10513c3a4
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011d6130 sp=0x140011d5910 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.ValidateBasicDecorator.AnteHandle({}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/basic.go:34 +0x104 fp=0x140011d6be0 sp=0x140011d6130 pc=0x105135dd4
github.com/cosmos/cosmos-sdk/x/auth/ante.(*ValidateBasicDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0x94 fp=0x140011d73f0 sp=0x140011d6be0 pc=0x10513bff4
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011d7c10 sp=0x140011d73f0 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.RejectExtensionOptionsDecorator.AnteHandle({_}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/ext.go:52 +0xd8 fp=0x140011d8420 sp=0x140011d7c10 pc=0x105136d18
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011d8c40 sp=0x140011d8420 pc=0x104dccee4
github.com/cosmos/cosmos-sdk/x/auth/ante.SetUpContextDecorator.AnteHandle({}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/ante/setup.go:70 +0x5c0 fp=0x140011db1a0 sp=0x140011d8c40 pc=0x105138350
github.com/cosmos/cosmos-sdk/x/auth/ante.(*SetUpContextDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0x94 fp=0x140011db9b0 sp=0x140011db1a0 pc=0x10513c664
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011dc1d0 sp=0x140011db9b0 pc=0x104dccee4
github.com/evmos/ethermint/app/ante.AuthzLimiterDecorator.AnteHandle({_}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/ethermint/app/ante/authz.go:54 +0x128 fp=0x140011dc9e0 sp=0x140011dc1d0 pc=0x105ee4338
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011dd200 sp=0x140011dc9e0 pc=0x104dccee4
github.com/evmos/ethermint/app/ante.RejectMessagesDecorator.AnteHandle({}, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/ethermint/app/ante/reject_msgs.go:40 +0x124 fp=0x140011dda10 sp=0x140011dd200 pc=0x105eeb834
github.com/evmos/ethermint/app/ante.(*RejectMessagesDecorator).AnteHandle(_, {{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, ...}, ...}, ...)
	<autogenerated>:1 +0x94 fp=0x140011de220 sp=0x140011dda10 pc=0x105eee294
github.com/cosmos/cosmos-sdk/types.ChainAnteDecorators.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/handler.go:49 +0xe4 fp=0x140011dea40 sp=0x140011de220 pc=0x104dccee4
github.com/evmos/ethermint/app/ante.NewAnteHandler.func1({{0x10909fd18, 0x10ac85bc0}, {0x1090b9710, 0x140016fe440}, {{0xb, 0x0}, {0x14002e29994, 0xc}, 0x3c, {0x2d8db288, ...}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/ethermint/app/ante/ante.go:90 +0x4e8 fp=0x140011df550 sp=0x140011dea40 pc=0x105ee3658
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0x14001921a00, 0x2, {0x1400061e800, 0xa90, 0xc00})
	/Users/mavis/Documents/crypto/cosmos-sdk/baseapp/baseapp.go:704 +0x3d8 fp=0x140011e2760 sp=0x140011df550 pc=0x1050fa6d8
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Simulate(...)
	/Users/mavis/Documents/crypto/cosmos-sdk/baseapp/test_helpers.go:25
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Simulate-fm({0x1400061e800?, 0x14001a42160?, 0x20?})
	<autogenerated>:1 +0x40 fp=0x140011e27a0 sp=0x140011e2760 pc=0x105287ab0
github.com/cosmos/cosmos-sdk/x/auth/tx.txServer.Simulate({{{0x0, 0x0, 0x0}, {0x1090bb1f0, 0x140009a22c0}, 0x0, {0x14001626980, 0xc}, {0x1090c7280, 0x14000cb3cf0}, ...}, ...}, ...)
	/Users/mavis/Documents/crypto/cosmos-sdk/x/auth/tx/service.go:132 +0x10c fp=0x140011e2850 sp=0x140011e27a0 pc=0x1051697ac
github.com/cosmos/cosmos-sdk/x/auth/tx.(*txServer).Simulate(0x10aba67b0?, {0x10909fff0?, 0x14003f90600?}, 0x140019453c8?)
	<autogenerated>:1 +0x8c fp=0x140011e2c10 sp=0x140011e2850 pc=0x10516ca3c
github.com/cosmos/cosmos-sdk/types/tx._Service_Simulate_Handler.func1({0x10909fff0?, 0x14003f90600?}, {0x108f38d20?, 0x14002f3c060?})
	/Users/mavis/Documents/crypto/cosmos-sdk/types/tx/service.pb.go:1423 +0xd0 fp=0x140011e2c50 sp=0x140011e2c10 pc=0x104e622a0
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func1({0x10909fff0, 0x140020626f0}, {0x108f38d20, 0x14002f3c060}, 0x14002f3c080?, 0x14002d921c8)
	/Users/mavis/Documents/crypto/cosmos-sdk/baseapp/grpcserver.go:68 +0x2d4 fp=0x140011e3760 sp=0x140011e2c50 pc=0x1050fe084
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2.ChainUnaryServer.1.1.1({0x10909fff0?, 0x140020626f0?}, {0x108f38d20?, 0x14002f3c060?})
	/Users/mavis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3c fp=0x140011e37a0 sp=0x140011e3760 pc=0x1050fdd6c
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1({0x10909fff0?, 0x140020626f0?}, {0x108f38d20?, 0x14002f3c060?}, 0x18?, 0x14002f3c080?)
	/Users/mavis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/recovery/interceptors.go:33 +0x98 fp=0x140011e3830 sp=0x140011e37a0 pc=0x1050ef848
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2.ChainUnaryServer.1.1.1({0x10909fff0?, 0x140020626f0?}, {0x108f38d20?, 0x14002f3c060?})
	/Users/mavis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3c fp=0x140011e3870 sp=0x140011e3830 pc=0x1050fdd6c
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2.ChainUnaryServer.1({0x10909fff0, 0x140020626f0}, {0x108f38d20, 0x14002f3c060}, 0x28?, 0x108d69280?)
	/Users/mavis/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0xb8 fp=0x140011e38d0 sp=0x140011e3870 pc=0x1050fdc28
github.com/cosmos/cosmos-sdk/types/tx._Service_Simulate_Handler({0x108f00f80, 0x14001cae000}, {0x10909fff0, 0x140020626f0}, 0x14002a08d00, 0x14002062720)
	/Users/mavis/Documents/crypto/cosmos-sdk/types/tx/service.pb.go:1425 +0x148 fp=0x140011e3920 sp=0x140011e38d0 pc=0x104e620e8
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2({0x108f00f80, 0x14001cae000}, {0x10909fff0, 0x140020626f0}, 0x14002a08d00, 0x14001358000?)
	/Users/mavis/Documents/crypto/cosmos-sdk/baseapp/grpcserver.go:82 +0x104 fp=0x140011e3980 sp=0x140011e3920 pc=0x1050fdb24
google.golang.org/grpc.(*Server).processUnaryRPC(0x140018be400, {0x10909fff0, 0x14002062660}, {0x1090b63c0, 0x14001278340}, 0x14001358000, 0x14001f63440, 0x1400190c1c0, 0x0)
	/Users/mavis/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1386 +0xb58 fp=0x140011e3d80 sp=0x140011e3980 pc=0x1049799d8
google.golang.org/grpc.(*Server).handleStream(0x140018be400, {0x1090b63c0, 0x14001278340}, 0x14001358000)
	/Users/mavis/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1797 +0xb10 fp=0x140011e3f60 sp=0x140011e3d80 pc=0x10497da20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/Users/mavis/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1027 +0x8c fp=0x140011e3fd0 sp=0x140011e3f60 pc=0x104977c5c
runtime.goexit({})
	/Users/mavis/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.darwin-arm64/src/runtime/asm_arm64.s:1222 +0x4 fp=0x140011e3fd0 sp=0x140011e3fd0 pc=0x10431da24
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 2887
	/Users/mavis/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1038 +0x13c

goroutine 1 gp=0x140000021c0 m=nil [semacquire, 1 minutes]:
</Details>
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
