### PR TITLE
Problem: signature verification result not cache between incarnations of same tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#252](https://github.com/crypto-org-chain/cosmos-sdk/pull/252) Add `BlockGasWanted` to `Context` to support feemarket module.
 * [#269](https://github.com/crypto-org-chain/cosmos-sdk/pull/269) Add `StreamingManager` to baseapp to extend the abci listeners.
 * (crypto/keyring) [#20212](https://github.com/cosmos/cosmos-sdk/pull/20212) Expose the db keyring used in the keystore.
+* (baseapp) [#]() Support incarnation cache when executed in block-stm.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#252](https://github.com/crypto-org-chain/cosmos-sdk/pull/252) Add `BlockGasWanted` to `Context` to support feemarket module.
 * [#269](https://github.com/crypto-org-chain/cosmos-sdk/pull/269) Add `StreamingManager` to baseapp to extend the abci listeners.
 * (crypto/keyring) [#20212](https://github.com/cosmos/cosmos-sdk/pull/20212) Expose the db keyring used in the keystore.
-* (baseapp) [#]() Support incarnation cache when executed in block-stm.
+* (baseapp) [#565](https://github.com/crypto-org-chain/cosmos-sdk/pull/565) Support incarnation cache when executed in block-stm.
 
 ### Improvements
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -842,8 +842,8 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Request
 
 func (app *BaseApp) executeTxs(ctx context.Context, txs [][]byte) ([]*abci.ExecTxResult, error) {
 	if app.txExecutor != nil {
-		return app.txExecutor(ctx, len(txs), app.finalizeBlockState.ms, func(i int, ms storetypes.MultiStore) *abci.ExecTxResult {
-			return app.deliverTxWithMultiStore(txs[i], i, ms)
+		return app.txExecutor(ctx, len(txs), app.finalizeBlockState.ms, func(i int, ms storetypes.MultiStore, incarnationCache map[string]any) *abci.ExecTxResult {
+			return app.deliverTxWithMultiStore(txs[i], i, ms, incarnationCache)
 		})
 	}
 

--- a/baseapp/txexecutor.go
+++ b/baseapp/txexecutor.go
@@ -12,5 +12,5 @@ type TxExecutor func(
 	ctx context.Context,
 	blockSize int,
 	cms types.MultiStore,
-	deliverTxWithMultiStore func(int, types.MultiStore) *abci.ExecTxResult,
+	deliverTxWithMultiStore func(int, types.MultiStore, map[string]any) *abci.ExecTxResult,
 ) ([]*abci.ExecTxResult, error)

--- a/types/context.go
+++ b/types/context.go
@@ -75,6 +75,9 @@ type Context struct {
 	blockGasUsed uint64
 	// sum the gas wanted by all the transactions in the current block, only accessible by end blocker
 	blockGasWanted uint64
+
+	// incarnationCache is shared between multiple incranations of the same transaction.
+	incarnationCache map[string]any
 }
 
 // Proposed rename, not done to avoid API breakage
@@ -107,6 +110,23 @@ func (c Context) MsgIndex() int                                 { return c.msgIn
 func (c Context) TxCount() int                                  { return c.txCount }
 func (c Context) BlockGasUsed() uint64                          { return c.blockGasUsed }
 func (c Context) BlockGasWanted() uint64                        { return c.blockGasWanted }
+func (c Context) IncarnationCache() map[string]any              { return c.incarnationCache }
+
+func (c Context) GetIncarnationCache(key string) (any, bool) {
+	if c.incarnationCache == nil {
+		return nil, false
+	}
+	val, ok := c.incarnationCache[key]
+	return val, ok
+}
+
+func (c Context) SetIncarnationCache(key string, value any) {
+	if c.incarnationCache == nil {
+		// noop if cache is not initialized
+		return
+	}
+	c.incarnationCache[key] = value
+}
 
 // BlockHeader returns the header by value (shallow copy).
 func (c Context) BlockHeader() cmtproto.Header {
@@ -349,6 +369,11 @@ func (c Context) WithBlockGasUsed(gasUsed uint64) Context {
 
 func (c Context) WithBlockGasWanted(gasWanted uint64) Context {
 	c.blockGasWanted = gasWanted
+	return c
+}
+
+func (c Context) WithIncarnationCache(cache map[string]any) Context {
+	c.incarnationCache = cache
 	return c
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -76,7 +76,8 @@ type Context struct {
 	// sum the gas wanted by all the transactions in the current block, only accessible by end blocker
 	blockGasWanted uint64
 
-	// incarnationCache is shared between multiple incranations of the same transaction.
+	// incarnationCache is shared between multiple incarnations of the same transaction,
+	// it must only cache stateless computation results, like the result of tx signature verification.
 	incarnationCache map[string]any
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -77,7 +77,7 @@ type Context struct {
 	blockGasWanted uint64
 
 	// incarnationCache is shared between multiple incarnations of the same transaction,
-	// it must only cache stateless computation results, like the result of tx signature verification.
+	// it must only cache stateless computation results that only depends on tx body and block level information that don't change during block execution, like the result of tx signature verification.
 	incarnationCache map[string]any
 }
 

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -31,6 +31,8 @@ var (
 	key                = make([]byte, secp256k1.PubKeySize)
 	simSecp256k1Pubkey = &secp256k1.PubKey{Key: key}
 	simSecp256k1Sig    [64]byte
+
+	SigVerificationResultCacheKey = "ante:SigVerificationResult"
 )
 
 func init() {
@@ -250,44 +252,44 @@ func OnlyLegacyAminoSigners(sigData signing.SignatureData) bool {
 	}
 }
 
-func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+func (svd SigVerificationDecorator) anteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool) error {
 	sigTx, ok := tx.(authsigning.Tx)
 	if !ok {
-		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+		return errorsmod.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
 	}
 
 	// stdSigs contains the sequence number, account number, and signatures.
 	// When simulating, this would just be a 0-length slice.
 	sigs, err := sigTx.GetSignaturesV2()
 	if err != nil {
-		return ctx, err
+		return err
 	}
 
 	signers, err := sigTx.GetSigners()
 	if err != nil {
-		return ctx, err
+		return err
 	}
 
 	// check that signer length and signature length are the same
 	if len(sigs) != len(signers) {
-		return ctx, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "invalid number of signer;  expected: %d, got %d", len(signers), len(sigs))
+		return errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "invalid number of signer;  expected: %d, got %d", len(signers), len(sigs))
 	}
 
 	for i, sig := range sigs {
 		acc, err := GetSignerAcc(ctx, svd.ak, signers[i])
 		if err != nil {
-			return ctx, err
+			return err
 		}
 
 		// retrieve pubkey
 		pubKey := acc.GetPubKey()
 		if !simulate && pubKey == nil {
-			return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
+			return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
 		}
 
 		// Check account sequence number.
 		if sig.Sequence != acc.GetSequence() {
-			return ctx, errorsmod.Wrapf(
+			return errorsmod.Wrapf(
 				sdkerrors.ErrWrongSequence,
 				"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
 			)
@@ -317,7 +319,7 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 			}
 			adaptableTx, ok := tx.(authsigning.V2AdaptableTx)
 			if !ok {
-				return ctx, fmt.Errorf("expected tx to implement V2AdaptableTx, got %T", tx)
+				return fmt.Errorf("expected tx to implement V2AdaptableTx, got %T", tx)
 			}
 			txData := adaptableTx.GetSigningTxData()
 			err = authsigning.VerifySignature(ctx, pubKey, signerData, sig.Data, svd.signModeHandler, txData)
@@ -330,12 +332,24 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 				} else {
 					errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d) and chain-id (%s): (%s)", accNum, chainID, err.Error())
 				}
-				return ctx, errorsmod.Wrap(sdkerrors.ErrUnauthorized, errMsg)
+				return errorsmod.Wrap(sdkerrors.ErrUnauthorized, errMsg)
 
 			}
 		}
 	}
+	return nil
+}
 
+func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	if v, ok := ctx.GetIncarnationCache(SigVerificationResultCacheKey); ok {
+		err = v.(error)
+	} else {
+		err = svd.anteHandle(ctx, tx, simulate)
+		ctx.SetIncarnationCache(SigVerificationResultCacheKey, err)
+	}
+	if err != nil {
+		return ctx, err
+	}
 	return next(ctx, tx, simulate)
 }
 

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -342,7 +342,10 @@ func (svd SigVerificationDecorator) anteHandle(ctx sdk.Context, tx sdk.Tx, simul
 
 func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	if v, ok := ctx.GetIncarnationCache(SigVerificationResultCacheKey); ok {
-		err = v.(error)
+		// can't convert `nil` to interface
+		if v != nil {
+			err = v.(error)
+		}
 	} else {
 		err = svd.anteHandle(ctx, tx, simulate)
 		ctx.SetIncarnationCache(SigVerificationResultCacheKey, err)


### PR DESCRIPTION
Closes: #564

Solution:
- introduce incarnation cache that's shared between incarnations of the same tx

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
