### PR TITLE
Problem: mempool iteration is not thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/bank) [#20028](https://github.com/cosmos/cosmos-sdk/pull/20028) Align query with multi denoms for send-enabled.
-* (baseapp) [#]() Fix data race in mempool iteration.
+* (baseapp) [#699](https://github.com/crypto-org-chain/cosmos-sdk/pull/699) Fix data race in mempool iteration.
 
 ## [Unreleased-Upstream]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/bank) [#20028](https://github.com/cosmos/cosmos-sdk/pull/20028) Align query with multi denoms for send-enabled.
+* (baseapp) [#]() Fix data race in mempool iteration.
 
 ## [Unreleased-Upstream]
 

--- a/baseapp/abci_utils.go
+++ b/baseapp/abci_utils.go
@@ -293,7 +293,7 @@ func (h *DefaultProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHan
 		h.mempool.SelectBy(ctx, req.Txs, func(memTx mempool.Tx) bool {
 			signerData, err := h.signerExtAdapter.GetSigners(memTx.Tx)
 			if err != nil {
-				// propogate the error to the caller
+				// propagate the error to the caller
 				resError = err
 				return false
 			}

--- a/types/mempool/mempool.go
+++ b/types/mempool/mempool.go
@@ -32,8 +32,7 @@ type Mempool interface {
 	InsertWithGasWanted(context.Context, sdk.Tx, uint64) error
 
 	// Select returns an Iterator over the app-side mempool. If txs are specified,
-	// then they shall be incorporated into the Iterator. The Iterator must
-	// closed by the caller.
+	// then they shall be incorporated into the Iterator. The Iterator is not thread-safe to use.
 	Select(context.Context, [][]byte) Iterator
 
 	// SelectBy use callback to iterate over the mempool.

--- a/types/mempool/mempool.go
+++ b/types/mempool/mempool.go
@@ -36,6 +36,9 @@ type Mempool interface {
 	// closed by the caller.
 	Select(context.Context, [][]byte) Iterator
 
+	// SelectBy use callback to iterate over the mempool.
+	SelectBy(context.Context, [][]byte, func(Tx) bool)
+
 	// CountTx returns the number of transactions currently in the mempool.
 	CountTx() int
 

--- a/types/mempool/noop.go
+++ b/types/mempool/noop.go
@@ -19,5 +19,6 @@ type NoOpMempool struct{}
 func (NoOpMempool) Insert(context.Context, sdk.Tx) error                      { return nil }
 func (NoOpMempool) InsertWithGasWanted(context.Context, sdk.Tx, uint64) error { return nil }
 func (NoOpMempool) Select(context.Context, [][]byte) Iterator                 { return nil }
+func (NoOpMempool) SelectBy(context.Context, [][]byte, func(Tx) bool)         {}
 func (NoOpMempool) CountTx() int                                              { return 0 }
 func (NoOpMempool) Remove(sdk.Tx) error                                       { return nil }

--- a/types/mempool/priority_nonce.go
+++ b/types/mempool/priority_nonce.go
@@ -361,9 +361,13 @@ func (i *PriorityNonceIterator[C]) Tx() Tx {
 //
 // NOTE: It is not safe to use this iterator while removing transactions from
 // the underlying mempool.
-func (mp *PriorityNonceMempool[C]) Select(_ context.Context, _ [][]byte) Iterator {
+func (mp *PriorityNonceMempool[C]) Select(ctx context.Context, txs [][]byte) Iterator {
 	mp.mtx.Lock()
 	defer mp.mtx.Unlock()
+	return mp.doSelect(ctx, txs)
+}
+
+func (mp *PriorityNonceMempool[C]) doSelect(_ context.Context, _ [][]byte) Iterator {
 	if mp.priorityIndex.Len() == 0 {
 		return nil
 	}
@@ -378,22 +382,11 @@ func (mp *PriorityNonceMempool[C]) Select(_ context.Context, _ [][]byte) Iterato
 	return iterator.iteratePriority()
 }
 
-func (mp *PriorityNonceMempool[C]) SelectBy(_ context.Context, _ [][]byte, callback func(Tx) bool) {
+func (mp *PriorityNonceMempool[C]) SelectBy(ctx context.Context, txs [][]byte, callback func(Tx) bool) {
 	mp.mtx.Lock()
 	defer mp.mtx.Unlock()
 
-	if mp.priorityIndex.Len() == 0 {
-		return
-	}
-
-	mp.reorderPriorityTies()
-
-	iterator := &PriorityNonceIterator[C]{
-		mempool:       mp,
-		senderCursors: make(map[string]*skiplist.Element),
-	}
-
-	iter := iterator.iteratePriority()
+	iter := mp.doSelect(ctx, txs)
 	for iter != nil && callback(iter.Tx()) {
 		iter = iter.Next()
 	}

--- a/types/mempool/priority_nonce.go
+++ b/types/mempool/priority_nonce.go
@@ -394,10 +394,7 @@ func (mp *PriorityNonceMempool[C]) SelectBy(_ context.Context, _ [][]byte, callb
 	}
 
 	iter := iterator.iteratePriority()
-	for iter != nil {
-		if !callback(iter.Tx()) {
-			break
-		}
+	for iter != nil && callback(iter.Tx()) {
 		iter = iter.Next()
 	}
 }

--- a/types/mempool/priority_nonce_test.go
+++ b/types/mempool/priority_nonce_test.go
@@ -474,6 +474,7 @@ func (s *MempoolTestSuite) TestIteratorConcurrency() {
 				}
 				return i < len(tt.txs)
 			})
+			require.Equal(t, i, len(tt.txs))
 			cancel()
 			wg.Wait()
 		})

--- a/types/mempool/priority_nonce_test.go
+++ b/types/mempool/priority_nonce_test.go
@@ -1,9 +1,11 @@
 package mempool_test
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -392,6 +394,88 @@ func (s *MempoolTestSuite) TestIterator() {
 				require.Equal(t, tt.txs[tx.id].a, tx.address)
 				iterator = iterator.Next()
 			}
+		})
+	}
+}
+
+func (s *MempoolTestSuite) TestIteratorConcurrency() {
+	t := s.T()
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(0)), 2)
+	sa := accounts[0].Address
+	sb := accounts[1].Address
+
+	tests := []struct {
+		txs  []txSpec
+		fail bool
+	}{
+		{
+			txs: []txSpec{
+				{p: 20, n: 1, a: sa},
+				{p: 15, n: 1, a: sb},
+				{p: 6, n: 2, a: sa},
+				{p: 21, n: 4, a: sa},
+				{p: 8, n: 2, a: sb},
+			},
+		},
+		{
+			txs: []txSpec{
+				{p: 20, n: 1, a: sa},
+				{p: 15, n: 1, a: sb},
+				{p: 6, n: 2, a: sa},
+				{p: 21, n: 4, a: sa},
+				{p: math.MinInt64, n: 2, a: sb},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			pool := mempool.DefaultPriorityMempool()
+
+			// create test txs and insert into mempool
+			for i, ts := range tt.txs {
+				tx := testTx{id: i, priority: int64(ts.p), nonce: uint64(ts.n), address: ts.a}
+				c := ctx.WithPriority(tx.priority)
+				err := pool.Insert(c, tx)
+				require.NoError(t, err)
+			}
+
+			// iterate through txs
+			stdCtx, cancel := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				id := len(tt.txs)
+				for {
+					select {
+					case <-stdCtx.Done():
+						return
+					default:
+						id++
+						tx := testTx{id: id, priority: int64(rand.Intn(100)), nonce: uint64(id), address: sa}
+						c := ctx.WithPriority(tx.priority)
+						err := pool.Insert(c, tx)
+						require.NoError(t, err)
+					}
+				}
+			}()
+
+			var i int
+			pool.SelectBy(ctx, nil, func(memTx mempool.Tx) bool {
+				tx := memTx.Tx.(testTx)
+				if tx.id < len(tt.txs) {
+					require.Equal(t, tt.txs[tx.id].p, int(tx.priority))
+					require.Equal(t, tt.txs[tx.id].n, int(tx.nonce))
+					require.Equal(t, tt.txs[tx.id].a, tx.address)
+					i++
+				}
+				return i < len(tt.txs)
+			})
+			cancel()
+			wg.Wait()
 		})
 	}
 }

--- a/types/mempool/sender_nonce.go
+++ b/types/mempool/sender_nonce.go
@@ -227,10 +227,7 @@ func (snm *SenderNonceMempool) SelectBy(_ context.Context, _ [][]byte, callback 
 	}
 
 	iter := iterator.Next()
-	for iter != nil {
-		if !callback(iter.Tx()) {
-			break
-		}
+	for iter != nil && callback(iter.Tx()) {
 		iter = iter.Next()
 	}
 }


### PR DESCRIPTION
Closes: #675

Solution:
- hold the lock during iteration, blocking concurrent modifications

A different approach than https://github.com/crypto-org-chain/cosmos-sdk/pull/681

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
