### PR TITLE
Problem: cannot unmarshal gov param into a *big.Int

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -214,4 +214,5 @@ replace (
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
+	cosmossdk.io/x/tx => ../x/tx
 )

--- a/x/tx/signing/aminojson/encoder.go
+++ b/x/tx/signing/aminojson/encoder.go
@@ -51,12 +51,7 @@ func cosmosDecEncoder(_ *Encoder, v protoreflect.Value, w io.Writer) error {
 		if val == "" {
 			return jsonMarshal(w, "0")
 		}
-		var dec math.LegacyDec
-		err := dec.Unmarshal([]byte(val))
-		if err != nil {
-			return err
-		}
-		return jsonMarshal(w, dec.String())
+		return jsonMarshal(w, val)
 	case []byte:
 		if len(val) == 0 {
 			return jsonMarshal(w, "0")


### PR DESCRIPTION
# Description

* when use back [LegacyDec](https://github.com/cosmos/cosmos-sdk/pull/22088)
* since main branch skip any cosmossdk.io/math.LegacyDec value,
* no need to unmarshal here, for more [info](https://github.com/cosmos/cosmos-sdk/blob/4274dcf4429cc725a3bda58410bd8325d721a3e9/x/tx/signing/aminojson/options.go#L134) 



<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
