### PR TITLE
Problem: miss EndBlock function calls before SimWriteState

### DIFF
--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -51,6 +51,12 @@ func (app *BaseApp) SimTxFinalizeBlock(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.
 	return gasInfo, result, err
 }
 
+// SimWriteState is an entrypoint for simulations only. They are not executed during the normal ABCI finalize
+// block step but later. Therefor an extra call to the root multi-store (app.cms) is required to write the changes.
+func (app *BaseApp) SimWriteState() {
+	app.finalizeBlockState.ms.Write()
+}
+
 // NewContextLegacy returns a new sdk.Context with the provided header
 func (app *BaseApp) NewContextLegacy(isCheckTx bool, header cmtproto.Header) sdk.Context {
 	if isCheckTx {

--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -177,6 +178,8 @@ type SelectOpFn func(r *rand.Rand) Operation
 type AppStateFn func(r *rand.Rand, accs []Account, config Config) (
 	appState json.RawMessage, accounts []Account, chainId string, genesisTimestamp time.Time,
 )
+
+type EndBlockFns func(ctx context.Context) error
 
 // RandomAccountFn returns a slice of n random simulation accounts
 type RandomAccountFn func(r *rand.Rand, n int) []Account

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -233,7 +233,7 @@ func SimulateFromSeed(
 		if config.Commit {
 			for _, endBlockFn := range endBlockFns {
 				if err := endBlockFn(ctx); err != nil {
-					return params, accs, fmt.Errorf("endBlockFn failed at height %d: %w", blockHeight, err)
+					return true, params, fmt.Errorf("endBlockFn failed at height %d: %w", blockHeight, err)
 				}
 			}
 			app.SimWriteState()

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -230,6 +230,7 @@ func SimulateFromSeed(
 		logWriter.AddEntry(EndBlockEntry(blockHeight))
 
 		if config.Commit {
+			app.SimWriteState()
 			app.Commit()
 		}
 


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
