### PR TITLE
fix: Remove `SigVerificationDecorator` Incarnation Cache Causing State Divergence Under Block-STM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (mempool) [#25563](https://github.com/cosmos/cosmos-sdk/pull/25563) Cleanup sender indices in case of tx replacement.
 * (cli) [#25485](https://github.com/cosmos/cosmos-sdk/pull/25485) Avoid failed to convert address field in `withdraw-validator-commission` cmd.
 * (baseapp) [#25642](https://github.com/cosmos/cosmos-sdk/pull/25642) Mark pre-block events for indexing based on local configuration.
+* (blockstm) [#1765](https://github.com/crypto-org-chain/cosmos-sdk/pull/1765) Remove `SigVerificationDecorator` signature incarnation cache causing state divergence under blockstm bug.
+
 
 ## [v0.53.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.4) - 2025-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (mempool) [#25563](https://github.com/cosmos/cosmos-sdk/pull/25563) Cleanup sender indices in case of tx replacement.
 * (cli) [#25485](https://github.com/cosmos/cosmos-sdk/pull/25485) Avoid failed to convert address field in `withdraw-validator-commission` cmd.
 * (baseapp) [#25642](https://github.com/cosmos/cosmos-sdk/pull/25642) Mark pre-block events for indexing based on local configuration.
-* (blockstm) [#1765](https://github.com/crypto-org-chain/cosmos-sdk/pull/1765) Remove `SigVerificationDecorator` signature incarnation cache causing state divergence under blockstm bug.
+* (blockstm) [#1765](https://github.com/crypto-org-chain/cosmos-sdk/pull/1765) Remove `SigVerificationDecorator` signature incarnation cache causing state divergence under blockstm.
 
 
 ## [v0.53.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.4) - 2025-07-25


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->
## Summary

The `SigVerificationDecorator` uses an **incarnation cache** to skip expensive signature verification when a transaction is re-executed by Block-STM. However, the cache wraps the **entire** `anteHandle` method — including **state-dependent** checks (account sequence, gas-consuming store reads) — not just the **stateless** signature verification. This causes determinism failures (app hash mismatch) between nodes running Block-STM and nodes running sequential execution.

## Background: Block-STM Re-execution

Block-STM executes transactions in parallel using optimistic concurrency. When two transactions conflict (e.g., both read/write the same account), the later transaction is **invalidated** and **re-executed** with a new **incarnation**:

```
Block with 2 txs from the same account (sequence = N):
  tx0: signed with sequence N
  tx1: signed with sequence N+1

Block-STM execution:
  Incarnation 1: tx0 and tx1 run in parallel
  → tx0 reads account (seq=N), passes, increments seq to N+1
  → tx1 reads account (seq=N, stale!), checks sig.Sequence(N+1) != acc.GetSequence()(N)
  → tx1 gets ErrWrongSequence
  
  Validation: tx1's read set is stale → tx1 is INVALIDATED
  
  Incarnation 2: tx1 re-executes
  → Now account has seq=N+1 (written by tx0)
  → Should pass: sig.Sequence(N+1) == acc.GetSequence()(N+1)
```

The **incarnation cache** is meant to avoid repeating expensive work (signature verification) across incarnations of the same transaction.

## The Bug: Caching State-Dependent Results

### Buggy Code (before fix)

```go
func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
    if v, ok := ctx.GetIncarnationCache(SigVerificationResultCacheKey); ok {
        // ❌ Cache HIT → skip EVERYTHING: GetSignerAcc, sequence check, VerifySignature
        if v != nil {
            err = v.(error)
        }
    } else {
        // Cache MISS → run full anteHandle (includes state-dependent checks)
        err = svd.anteHandle(ctx, tx, simulate)
        ctx.SetIncarnationCache(SigVerificationResultCacheKey, err) // ❌ caches state-dependent result
    }
    if err != nil {
        return ctx, err
    }
    return next(ctx, tx, simulate)
}
```

The `anteHandle` method does three things:

| Step | Function | State-dependent? | Safe to cache? |
|------|----------|:-:|:-:|
| 1 | `GetSignerAcc(ctx, ak, signer)` — reads account from KV store | ✅ Yes (consumes gas) | ❌ No |
| 2 | `sig.Sequence != acc.GetSequence()` — checks account sequence | ✅ Yes (reads current state) | ❌ No |
| 3 | `VerifySignature(pubKey, signerData, sig.Data)` — signature verification | ❌ No (pure computation) | ✅ Yes |

By caching the entire result, **all three steps are skipped on cache hit**. The following are two examples of how this leads to state divergence (not exhaustive):

---

## Problem 1: Stale Sequence Error → Transaction Outcome Divergence

When **two transactions from the same account** are in the same block, the incarnation cache replays a stale `ErrWrongSequence` from an earlier incarnation, causing a transaction to fail under Block-STM that would succeed under sequential execution.

### Sequence Diagram

```
┌─────────────────────────────────────────────────────────────────────┐
│ Incarnation 1: tx0 and tx1 execute in parallel                     │
├────────────────────────────────┬────────────────────────────────────┤
│           tx0                  │             tx1                    │
│                                │                                    │
│  GetSignerAcc → acc.seq = N    │  GetSignerAcc → acc.seq = N       │
│  sig.Sequence(N) == N  ✅      │  sig.Sequence(N+1) != N  ❌        │
│  VerifySignature → OK          │  → ErrWrongSequence                │
│  ... increments seq to N+1     │  → CACHED: ErrWrongSequence        │
├────────────────────────────────┴────────────────────────────────────┤
│ Validation: tx1 read stale data → tx1 INVALIDATED → re-execute     │
├─────────────────────────────────────────────────────────────────────┤
│ Incarnation 2: tx1 re-executes                                     │
│                                                                     │
│  ⚠️  Cache HIT → returns cached ErrWrongSequence                    │
│  GetSignerAcc is SKIPPED (would have read acc.seq = N+1)            │
│  Sequence check is SKIPPED (would have passed: N+1 == N+1)          │
│                                                                     │
│  Result: tx1 FAILS with code 32 (ErrWrongSequence)                  │
└─────────────────────────────────────────────────────────────────────┘

Sequential execution:
┌─────────────────────────────────────────────────────────────────────┐
│ tx0 executes first                                                  │
│  GetSignerAcc → acc.seq = N, passes, increments seq to N+1          │
├─────────────────────────────────────────────────────────────────────┤
│ tx1 executes second                                                 │
│  GetSignerAcc → acc.seq = N+1                                       │
│  sig.Sequence(N+1) == N+1  ✅ → tx1 SUCCEEDS                       │
└─────────────────────────────────────────────────────────────────────┘
```

### Consequence

| | Block-STM | Sequential |
|---|---|---|
| tx1 result | ❌ FAILS (code 32) | ✅ SUCCEEDS |
| tx1 state changes | None (rolled back) | Applied |

**→ State divergence. App hash mismatch. Consensus failure.**

---

## Problem 2: Skipped Gas Consumption → Gas Divergence

Even when transactions are from **different accounts** (no sequence conflict), the incarnation cache still causes non-determinism through gas metering differences.

When the cache hits on a re-executed incarnation, `GetSignerAcc` is skipped. This function performs a store read that **consumes gas**. Skipping it produces a lower `gas_used` for the transaction compared to sequential execution.

```
tx1 under Block-STM (re-executed, cache hit):
  GetSignerAcc SKIPPED → gas_used is lower

tx1 under Sequential:
  GetSignerAcc runs → gas_used is higher

Different gas_used → different execution path/state
  → App hash mismatch
```

---

## The Fix

Remove the incarnation cache from `SigVerificationDecorator` entirely. The signature verification result is no longer cached across Block-STM incarnations.

### Why not cache just `VerifySignature`?

At first glance, it seems feasible to narrow the cache scope to only the stateless `VerifySignature` call (step 3 in the table above), while always re-executing the state-dependent parts. However, `VerifySignature` is not purely stateless either — the signing pipeline can make **stateful calls** depending on the sign mode:

- **`SIGN_MODE_TEXTUAL`**: `GetSignBytes` invokes a `coinMetadataQuerier` that reads **bank module state** (coin denomination metadata) to render human-readable transaction summaries. This is a KV store read that consumes gas and can vary between incarnations.
- **`SIGN_MODE_DIRECT`** and **`SIGN_MODE_LEGACY_AMINO_JSON`**: These are pretty much 'stateless' today since fields like `accNum`,`address` are pretty much immutable, but the signing handler interface (`HandlerMap.GetSignBytes`) accepts a `context.Context`, meaning any sign mode implementation could introduce state dependencies in the future.

Because `GetSignBytes` is called inside `VerifySignature` and can touch state, caching the result of `VerifySignature` would still skip gas-consuming store reads or read stale data on cache hit, leading to the same gas divergence described in Problem 1 or 2.

Making signature verification fully cacheable would require changes to the signing mechanism — for example, ensuring all sign mode handlers are pure functions of their inputs with no state access, or separating the `GetSignBytes` computation (which may be stateful) from the actual cryptographic verification (which is always stateless). This is out of scope for this fix.

### What changed

| Behavior | Before (buggy) | After (fixed) |
|---|---|---|
| `GetSignerAcc` on cache hit | ❌ Skipped (no gas) | ✅ Always runs |
| Sequence check on cache hit | ❌ Skipped (stale result) | ✅ Always re-evaluated |
| `VerifySignature` on cache hit | ❌ Skipped (cached) | ✅ Always runs |
| Incarnation cache usage | Caches entire `AnteHandle` result | No caching |
| Gas determinism | ❌ Block-STM ≠ Sequential | ✅ Identical |
| Sequence correctness | ❌ Stale errors/successes | ✅ Current state |

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
