### PR TITLE
feat: optimize staking EndBlock/BeginBlock queue iterators

### DIFF
--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -244,7 +244,7 @@ func SimulateFromSeedX(
 
 		if config.Commit {
 			// this is to be commented out for ethermint simulation tests to pass as this prevents
-			// inconsistent state to be committed during simulation 
+			// inconsistent state to be committed during simulation
 			// app.SimWriteState()
 			if _, err := app.Commit(); err != nil {
 				return params, accs, fmt.Errorf("commit failed at height %d: %w", blockHeight, err)

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
@@ -482,8 +483,67 @@ func (k Keeper) GetUBDQueueTimeSlice(ctx context.Context, timestamp time.Time) (
 	return pairs.Pairs, err
 }
 
+// getUBDPendingTimes reads the sorted list of completion timestamps that have UBD queue entries.
+// Value format: 4-byte count (big-endian uint32) + 8-byte UnixNano (big-endian) per time.
+func (k Keeper) getUBDPendingTimes(ctx context.Context) ([]time.Time, error) {
+	store := k.storeService.OpenKVStore(ctx)
+	bz, err := store.Get(types.UBDPendingTimesKey)
+	if err != nil || len(bz) < 4 {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(bz[:4])
+	if n == 0 || len(bz) < 4+int(n)*8 {
+		return nil, nil
+	}
+	out := make([]time.Time, 0, n)
+	for i := uint32(0); i < n; i++ {
+		off := 4 + i*8
+		nanos := int64(binary.BigEndian.Uint64(bz[off : off+8]))
+		out = append(out, time.Unix(0, nanos))
+	}
+	return out, nil
+}
+
+// setUBDPendingTimes writes the sorted list of completion timestamps.
+func (k Keeper) setUBDPendingTimes(ctx context.Context, times []time.Time) error {
+	store := k.storeService.OpenKVStore(ctx)
+	if len(times) == 0 {
+		_ = store.Delete(types.UBDPendingTimesKey)
+		return nil
+	}
+	bz := make([]byte, 4+len(times)*8)
+	binary.BigEndian.PutUint32(bz[:4], uint32(len(times)))
+	for i, t := range times {
+		binary.BigEndian.PutUint64(bz[4+i*8:4+(i+1)*8], uint64(t.UnixNano()))
+	}
+	return store.Set(types.UBDPendingTimesKey, bz)
+}
+
+// addUBDPendingTime inserts timestamp into the pending list (sorted, no duplicate).
+func (k Keeper) addUBDPendingTime(ctx context.Context, timestamp time.Time) error {
+	times, err := k.getUBDPendingTimes(ctx)
+	if err != nil {
+		return err
+	}
+	nanos := timestamp.UnixNano()
+	for _, t := range times {
+		if t.UnixNano() == nanos {
+			return nil
+		}
+	}
+	// insert in sorted order
+	i := 0
+	for i < len(times) && times[i].UnixNano() < nanos {
+		i++
+	}
+	times = append(times, time.Time{})
+	copy(times[i+1:], times[i:])
+	times[i] = timestamp
+	return k.setUBDPendingTimes(ctx, times)
+}
+
 // SetUBDQueueTimeSlice sets a specific unbonding queue timeslice.
-// Updates UBDQueueHeadKey when this timeslice is earlier than the current queue head.
+// Updates UBDQueueHeadKey and UBDPendingTimesKey when this timeslice is earlier than the current queue head.
 func (k Keeper) SetUBDQueueTimeSlice(ctx context.Context, timestamp time.Time, keys []types.DVPair) error {
 	store := k.storeService.OpenKVStore(ctx)
 	key := types.GetUnbondingDelegationTimeKey(timestamp)
@@ -492,6 +552,9 @@ func (k Keeper) SetUBDQueueTimeSlice(ctx context.Context, timestamp time.Time, k
 		return err
 	}
 	if err = store.Set(key, bz); err != nil {
+		return err
+	}
+	if err = k.addUBDPendingTime(ctx, timestamp); err != nil {
 		return err
 	}
 	headVal, _ := store.Get(types.UBDQueueHeadKey)
@@ -522,78 +585,110 @@ func (k Keeper) InsertUBDQueue(ctx context.Context, ubd types.UnbondingDelegatio
 	return k.SetUBDQueueTimeSlice(ctx, completionTime, timeSlice)
 }
 
-// UBDQueueIterator returns all the unbonding queue timeslices from the queue head (or prefix start) until endTime.
-// When UBDQueueHeadKey is set, iteration starts from that key to avoid scanning from time 0 each block.
-func (k Keeper) UBDQueueIterator(ctx context.Context, endTime time.Time) (corestore.Iterator, error) {
-	store := k.storeService.OpenKVStore(ctx)
-	endKey := storetypes.InclusiveEndBytes(types.GetUnbondingDelegationTimeKey(endTime))
-	headVal, err := store.Get(types.UBDQueueHeadKey)
-	if err != nil {
-		return nil, err
-	}
-	if len(headVal) > len(types.UnbondingQueueKey) {
-		headTime, err := sdk.ParseTimeBytes(headVal[len(types.UnbondingQueueKey):])
-		if err == nil && !headTime.After(endTime) {
-			return store.Iterator(headVal, endKey)
-		}
-	}
-	return store.Iterator(types.UnbondingQueueKey, endKey)
-}
-
 // DequeueAllMatureUBDQueue returns a concatenated list of all the timeslices inclusively previous to
-// currTime, and deletes the timeslices from the queue. Updates UBDQueueHeadKey so the next block
-// can start iteration from the new head instead of from the prefix start.
+// currTime, and deletes the timeslices from the queue. Uses the pending-times list when available
+// (point Get/Delete only, no range iterator) to avoid expensive SST scans in LSM stores.
+// Falls back to the iterator path when the pending list is empty (e.g. after upgrade).
 func (k Keeper) DequeueAllMatureUBDQueue(ctx context.Context, currTime time.Time) (matureUnbonds []types.DVPair, err error) {
 	store := k.storeService.OpenKVStore(ctx)
-
-	// Early exit when no mature entries: if queue head is after currTime, skip iterator entirely.
-	headVal, err := store.Get(types.UBDQueueHeadKey)
+	pending, err := k.getUBDPendingTimes(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(headVal) > len(types.UnbondingQueueKey) {
-		headTime, err := sdk.ParseTimeBytes(headVal[len(types.UnbondingQueueKey):])
-		if err == nil && headTime.After(currTime) {
-			return nil, nil
+	if len(pending) > 0 {
+		return k.dequeueAllMatureUBDQueueFromPending(ctx, store, currTime, pending)
+	}
+	return k.dequeueAllMatureUBDQueueWithIterator(ctx, store, currTime)
+}
+
+// dequeueAllMatureUBDQueueFromPending processes mature UBD entries using the pending-times list (point Get/Delete only).
+func (k Keeper) dequeueAllMatureUBDQueueFromPending(ctx context.Context, store corestore.KVStore, currTime time.Time, pending []time.Time) (matureUnbonds []types.DVPair, err error) {
+	var remaining []time.Time
+	for i, t := range pending {
+		if t.After(currTime) {
+			remaining = append(remaining, pending[i:]...)
+			break
+		}
+		key := types.GetUnbondingDelegationTimeKey(t)
+		bz, err := store.Get(key)
+		if err != nil {
+			return matureUnbonds, err
+		}
+		if bz == nil {
+			continue
+		}
+		var timeslice types.DVPairs
+		if err = k.cdc.Unmarshal(bz, &timeslice); err != nil {
+			return matureUnbonds, err
+		}
+		matureUnbonds = append(matureUnbonds, timeslice.Pairs...)
+		if err = store.Delete(key); err != nil {
+			return matureUnbonds, err
 		}
 	}
-
-	unbondingTimesliceIterator, err := k.UBDQueueIterator(ctx, currTime)
-	if err != nil {
+	if err = k.setUBDPendingTimes(ctx, remaining); err != nil {
 		return matureUnbonds, err
 	}
-	defer unbondingTimesliceIterator.Close()
-
-	var nextHead []byte
-	for unbondingTimesliceIterator.Valid() {
-		timeslice := types.DVPairs{}
-		value := unbondingTimesliceIterator.Value()
-		if err = k.cdc.Unmarshal(value, &timeslice); err != nil {
-			return matureUnbonds, err
-		}
-
-		matureUnbonds = append(matureUnbonds, timeslice.Pairs...)
-
-		if err = store.Delete(unbondingTimesliceIterator.Key()); err != nil {
-			return matureUnbonds, err
-		}
-
-		unbondingTimesliceIterator.Next()
-		if unbondingTimesliceIterator.Valid() {
-			nextHead = unbondingTimesliceIterator.Key()
-		} else {
-			nextHead = nil
-		}
-	}
-
-	if nextHead != nil {
-		if err = store.Set(types.UBDQueueHeadKey, nextHead); err != nil {
-			return matureUnbonds, err
-		}
+	if len(remaining) > 0 {
+		_ = store.Set(types.UBDQueueHeadKey, types.GetUnbondingDelegationTimeKey(remaining[0]))
 	} else {
 		_ = store.Delete(types.UBDQueueHeadKey)
 	}
+	return matureUnbonds, nil
+}
 
+// dequeueAllMatureUBDQueueWithIterator is the fallback path using a range iterator (e.g. when pending list is empty after upgrade).
+// Uses a single full-range iterator: processes mature entries and collects remaining times in one pass, then sets pending list.
+func (k Keeper) dequeueAllMatureUBDQueueWithIterator(ctx context.Context, store corestore.KVStore, currTime time.Time) (matureUnbonds []types.DVPair, err error) {
+	startKey := types.UnbondingQueueKey
+	headVal, err := store.Get(types.UBDQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.UnbondingQueueKey) {
+		headTime, parseErr := sdk.ParseTimeBytes(headVal[len(types.UnbondingQueueKey):])
+		if parseErr == nil && headTime.After(currTime) {
+			return nil, nil
+		}
+		startKey = headVal
+	}
+
+	endKey := storetypes.PrefixEndBytes(types.UnbondingQueueKey)
+	it, err := store.Iterator(startKey, endKey)
+	if err != nil {
+		return matureUnbonds, err
+	}
+	defer it.Close()
+
+	var remainingTimes []time.Time
+	for ; it.Valid(); it.Next() {
+		key := it.Key()
+		t, parseErr := sdk.ParseTimeBytes(key[len(types.UnbondingQueueKey):])
+		if parseErr != nil {
+			continue
+		}
+		if t.After(currTime) {
+			remainingTimes = append(remainingTimes, t)
+			continue
+		}
+		var timeslice types.DVPairs
+		if err = k.cdc.Unmarshal(it.Value(), &timeslice); err != nil {
+			return matureUnbonds, err
+		}
+		matureUnbonds = append(matureUnbonds, timeslice.Pairs...)
+		if err = store.Delete(key); err != nil {
+			return matureUnbonds, err
+		}
+	}
+
+	if err = k.setUBDPendingTimes(ctx, remainingTimes); err != nil {
+		return matureUnbonds, err
+	}
+	if len(remainingTimes) > 0 {
+		_ = store.Set(types.UBDQueueHeadKey, types.GetUnbondingDelegationTimeKey(remainingTimes[0]))
+	} else {
+		_ = store.Delete(types.UBDQueueHeadKey)
+	}
 	return matureUnbonds, nil
 }
 
@@ -840,8 +935,65 @@ func (k Keeper) GetRedelegationQueueTimeSlice(ctx context.Context, timestamp tim
 	return triplets.Triplets, nil
 }
 
+// getRedelegationPendingTimes reads the sorted list of completion timestamps that have redelegation queue entries.
+func (k Keeper) getRedelegationPendingTimes(ctx context.Context) ([]time.Time, error) {
+	store := k.storeService.OpenKVStore(ctx)
+	bz, err := store.Get(types.RedelegationPendingTimesKey)
+	if err != nil || len(bz) < 4 {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(bz[:4])
+	if n == 0 || len(bz) < 4+int(n)*8 {
+		return nil, nil
+	}
+	out := make([]time.Time, 0, n)
+	for i := uint32(0); i < n; i++ {
+		off := 4 + i*8
+		nanos := int64(binary.BigEndian.Uint64(bz[off : off+8]))
+		out = append(out, time.Unix(0, nanos))
+	}
+	return out, nil
+}
+
+// setRedelegationPendingTimes writes the sorted list of completion timestamps.
+func (k Keeper) setRedelegationPendingTimes(ctx context.Context, times []time.Time) error {
+	store := k.storeService.OpenKVStore(ctx)
+	if len(times) == 0 {
+		_ = store.Delete(types.RedelegationPendingTimesKey)
+		return nil
+	}
+	bz := make([]byte, 4+len(times)*8)
+	binary.BigEndian.PutUint32(bz[:4], uint32(len(times)))
+	for i, t := range times {
+		binary.BigEndian.PutUint64(bz[4+i*8:4+(i+1)*8], uint64(t.UnixNano()))
+	}
+	return store.Set(types.RedelegationPendingTimesKey, bz)
+}
+
+// addRedelegationPendingTime inserts timestamp into the pending list (sorted, no duplicate).
+func (k Keeper) addRedelegationPendingTime(ctx context.Context, timestamp time.Time) error {
+	times, err := k.getRedelegationPendingTimes(ctx)
+	if err != nil {
+		return err
+	}
+	nanos := timestamp.UnixNano()
+	for _, t := range times {
+		if t.UnixNano() == nanos {
+			return nil
+		}
+	}
+	i := 0
+	for i < len(times) && times[i].UnixNano() < nanos {
+		i++
+	}
+	times = append(times, time.Time{})
+	copy(times[i+1:], times[i:])
+	times[i] = timestamp
+	return k.setRedelegationPendingTimes(ctx, times)
+}
+
 // SetRedelegationQueueTimeSlice sets a specific redelegation queue timeslice.
-// Updates RedelegationQueueHeadKey when this timeslice is earlier than the current queue head.
+// Updates RedelegationQueueHeadKey and RedelegationPendingTimesKey when this timeslice is earlier than the current queue head.
 func (k Keeper) SetRedelegationQueueTimeSlice(ctx context.Context, timestamp time.Time, keys []types.DVVTriplet) error {
 	store := k.storeService.OpenKVStore(ctx)
 	key := types.GetRedelegationTimeKey(timestamp)
@@ -850,6 +1002,9 @@ func (k Keeper) SetRedelegationQueueTimeSlice(ctx context.Context, timestamp tim
 		return err
 	}
 	if err = store.Set(key, bz); err != nil {
+		return err
+	}
+	if err = k.addRedelegationPendingTime(ctx, timestamp); err != nil {
 		return err
 	}
 	headVal, _ := store.Get(types.RedelegationQueueHeadKey)
@@ -880,81 +1035,110 @@ func (k Keeper) InsertRedelegationQueue(ctx context.Context, red types.Redelegat
 	return k.SetRedelegationQueueTimeSlice(ctx, completionTime, timeSlice)
 }
 
-// RedelegationQueueIterator returns all the redelegation queue timeslices from
-// the queue head (or prefix start) until endTime. When RedelegationQueueHeadKey is set,
-// iteration starts from that key to avoid scanning from time 0 each block.
-func (k Keeper) RedelegationQueueIterator(ctx context.Context, endTime time.Time) (storetypes.Iterator, error) {
-	store := k.storeService.OpenKVStore(ctx)
-	endKey := storetypes.InclusiveEndBytes(types.GetRedelegationTimeKey(endTime))
-	headVal, err := store.Get(types.RedelegationQueueHeadKey)
-	if err != nil {
-		return nil, err
-	}
-	if len(headVal) > len(types.RedelegationQueueKey) {
-		headTime, err := sdk.ParseTimeBytes(headVal[len(types.RedelegationQueueKey):])
-		if err == nil && !headTime.After(endTime) {
-			return store.Iterator(headVal, endKey)
-		}
-	}
-	return store.Iterator(types.RedelegationQueueKey, endKey)
-}
-
 // DequeueAllMatureRedelegationQueue returns a concatenated list of all the
 // timeslices inclusively previous to currTime, and deletes the timeslices from
-// the queue. Updates RedelegationQueueHeadKey so the next block can start
-// iteration from the new head instead of from the prefix start.
+// the queue. Uses the pending-times list when available (point Get/Delete only)
+// to avoid expensive SST scans in LSM stores. Falls back to the iterator path when the pending list is empty.
 func (k Keeper) DequeueAllMatureRedelegationQueue(ctx context.Context, currTime time.Time) (matureRedelegations []types.DVVTriplet, err error) {
 	store := k.storeService.OpenKVStore(ctx)
-
-	// Early exit when no mature entries: if queue head is after currTime, skip iterator entirely.
-	headVal, err := store.Get(types.RedelegationQueueHeadKey)
+	pending, err := k.getRedelegationPendingTimes(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(headVal) > len(types.RedelegationQueueKey) {
-		headTime, err := sdk.ParseTimeBytes(headVal[len(types.RedelegationQueueKey):])
-		if err == nil && headTime.After(currTime) {
-			return nil, nil
-		}
+	if len(pending) > 0 {
+		return k.dequeueAllMatureRedelegationQueueFromPending(ctx, store, currTime, pending)
 	}
+	return k.dequeueAllMatureRedelegationQueueWithIterator(ctx, store, currTime)
+}
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	redelegationTimesliceIterator, err := k.RedelegationQueueIterator(ctx, sdkCtx.HeaderInfo().Time)
-	if err != nil {
-		return nil, err
-	}
-	defer redelegationTimesliceIterator.Close()
-
-	var nextHead []byte
-	for redelegationTimesliceIterator.Valid() {
-		timeslice := types.DVVTriplets{}
-		value := redelegationTimesliceIterator.Value()
-		if err = k.cdc.Unmarshal(value, &timeslice); err != nil {
-			return nil, err
+// dequeueAllMatureRedelegationQueueFromPending processes mature redelegation entries using the pending-times list (point Get/Delete only).
+func (k Keeper) dequeueAllMatureRedelegationQueueFromPending(ctx context.Context, store corestore.KVStore, currTime time.Time, pending []time.Time) (matureRedelegations []types.DVVTriplet, err error) {
+	var remaining []time.Time
+	for i, t := range pending {
+		if t.After(currTime) {
+			remaining = append(remaining, pending[i:]...)
+			break
 		}
-
-		matureRedelegations = append(matureRedelegations, timeslice.Triplets...)
-
-		if err = store.Delete(redelegationTimesliceIterator.Key()); err != nil {
-			return nil, err
-		}
-
-		redelegationTimesliceIterator.Next()
-		if redelegationTimesliceIterator.Valid() {
-			nextHead = redelegationTimesliceIterator.Key()
-		} else {
-			nextHead = nil
-		}
-	}
-
-	if nextHead != nil {
-		if err = store.Set(types.RedelegationQueueHeadKey, nextHead); err != nil {
+		key := types.GetRedelegationTimeKey(t)
+		bz, err := store.Get(key)
+		if err != nil {
 			return matureRedelegations, err
 		}
+		if bz == nil {
+			continue
+		}
+		var timeslice types.DVVTriplets
+		if err = k.cdc.Unmarshal(bz, &timeslice); err != nil {
+			return matureRedelegations, err
+		}
+		matureRedelegations = append(matureRedelegations, timeslice.Triplets...)
+		if err = store.Delete(key); err != nil {
+			return matureRedelegations, err
+		}
+	}
+	if err = k.setRedelegationPendingTimes(ctx, remaining); err != nil {
+		return matureRedelegations, err
+	}
+	if len(remaining) > 0 {
+		_ = store.Set(types.RedelegationQueueHeadKey, types.GetRedelegationTimeKey(remaining[0]))
 	} else {
 		_ = store.Delete(types.RedelegationQueueHeadKey)
 	}
+	return matureRedelegations, nil
+}
 
+// dequeueAllMatureRedelegationQueueWithIterator is the fallback path using a range iterator.
+// Uses a single full-range iterator: processes mature entries and collects remaining times in one pass, then sets pending list.
+func (k Keeper) dequeueAllMatureRedelegationQueueWithIterator(ctx context.Context, store corestore.KVStore, currTime time.Time) (matureRedelegations []types.DVVTriplet, err error) {
+	startKey := types.RedelegationQueueKey
+	headVal, err := store.Get(types.RedelegationQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.RedelegationQueueKey) {
+		headTime, parseErr := sdk.ParseTimeBytes(headVal[len(types.RedelegationQueueKey):])
+		if parseErr == nil && headTime.After(currTime) {
+			return nil, nil
+		}
+		startKey = headVal
+	}
+
+	endKey := storetypes.PrefixEndBytes(types.RedelegationQueueKey)
+	it, err := store.Iterator(startKey, endKey)
+	if err != nil {
+		return matureRedelegations, err
+	}
+	defer it.Close()
+
+	var remainingTimes []time.Time
+	for ; it.Valid(); it.Next() {
+		key := it.Key()
+		t, parseErr := sdk.ParseTimeBytes(key[len(types.RedelegationQueueKey):])
+		if parseErr != nil {
+			continue
+		}
+		if t.After(currTime) {
+			remainingTimes = append(remainingTimes, t)
+			continue
+		}
+		var timeslice types.DVVTriplets
+		if err = k.cdc.Unmarshal(it.Value(), &timeslice); err != nil {
+			return matureRedelegations, err
+		}
+		matureRedelegations = append(matureRedelegations, timeslice.Triplets...)
+		if err = store.Delete(key); err != nil {
+			return matureRedelegations, err
+		}
+	}
+
+	if err = k.setRedelegationPendingTimes(ctx, remainingTimes); err != nil {
+		return matureRedelegations, err
+	}
+	if len(remainingTimes) > 0 {
+		_ = store.Set(types.RedelegationQueueHeadKey, types.GetRedelegationTimeKey(remainingTimes[0]))
+	} else {
+		_ = store.Delete(types.RedelegationQueueHeadKey)
+	}
 	return matureRedelegations, nil
 }
 

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -483,13 +483,22 @@ func (k Keeper) GetUBDQueueTimeSlice(ctx context.Context, timestamp time.Time) (
 }
 
 // SetUBDQueueTimeSlice sets a specific unbonding queue timeslice.
+// Updates UBDQueueHeadKey when this timeslice is earlier than the current queue head.
 func (k Keeper) SetUBDQueueTimeSlice(ctx context.Context, timestamp time.Time, keys []types.DVPair) error {
 	store := k.storeService.OpenKVStore(ctx)
+	key := types.GetUnbondingDelegationTimeKey(timestamp)
 	bz, err := k.cdc.Marshal(&types.DVPairs{Pairs: keys})
 	if err != nil {
 		return err
 	}
-	return store.Set(types.GetUnbondingDelegationTimeKey(timestamp), bz)
+	if err = store.Set(key, bz); err != nil {
+		return err
+	}
+	headVal, _ := store.Get(types.UBDQueueHeadKey)
+	if len(headVal) == 0 || bytes.Compare(key, headVal) < 0 {
+		return store.Set(types.UBDQueueHeadKey, key)
+	}
+	return nil
 }
 
 // InsertUBDQueue inserts an unbonding delegation to the appropriate timeslice
@@ -513,26 +522,50 @@ func (k Keeper) InsertUBDQueue(ctx context.Context, ubd types.UnbondingDelegatio
 	return k.SetUBDQueueTimeSlice(ctx, completionTime, timeSlice)
 }
 
-// UBDQueueIterator returns all the unbonding queue timeslices from time 0 until endTime.
+// UBDQueueIterator returns all the unbonding queue timeslices from the queue head (or prefix start) until endTime.
+// When UBDQueueHeadKey is set, iteration starts from that key to avoid scanning from time 0 each block.
 func (k Keeper) UBDQueueIterator(ctx context.Context, endTime time.Time) (corestore.Iterator, error) {
 	store := k.storeService.OpenKVStore(ctx)
-	return store.Iterator(types.UnbondingQueueKey,
-		storetypes.InclusiveEndBytes(types.GetUnbondingDelegationTimeKey(endTime)))
+	endKey := storetypes.InclusiveEndBytes(types.GetUnbondingDelegationTimeKey(endTime))
+	headVal, err := store.Get(types.UBDQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.UnbondingQueueKey) {
+		headTime, err := sdk.ParseTimeBytes(headVal[len(types.UnbondingQueueKey):])
+		if err == nil && !headTime.After(endTime) {
+			return store.Iterator(headVal, endKey)
+		}
+	}
+	return store.Iterator(types.UnbondingQueueKey, endKey)
 }
 
 // DequeueAllMatureUBDQueue returns a concatenated list of all the timeslices inclusively previous to
-// currTime, and deletes the timeslices from the queue.
+// currTime, and deletes the timeslices from the queue. Updates UBDQueueHeadKey so the next block
+// can start iteration from the new head instead of from the prefix start.
 func (k Keeper) DequeueAllMatureUBDQueue(ctx context.Context, currTime time.Time) (matureUnbonds []types.DVPair, err error) {
 	store := k.storeService.OpenKVStore(ctx)
 
-	// gets an iterator for all timeslices from time 0 until the current Blockheader time
+	// Early exit when no mature entries: if queue head is after currTime, skip iterator entirely.
+	headVal, err := store.Get(types.UBDQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.UnbondingQueueKey) {
+		headTime, err := sdk.ParseTimeBytes(headVal[len(types.UnbondingQueueKey):])
+		if err == nil && headTime.After(currTime) {
+			return nil, nil
+		}
+	}
+
 	unbondingTimesliceIterator, err := k.UBDQueueIterator(ctx, currTime)
 	if err != nil {
 		return matureUnbonds, err
 	}
 	defer unbondingTimesliceIterator.Close()
 
-	for ; unbondingTimesliceIterator.Valid(); unbondingTimesliceIterator.Next() {
+	var nextHead []byte
+	for unbondingTimesliceIterator.Valid() {
 		timeslice := types.DVPairs{}
 		value := unbondingTimesliceIterator.Value()
 		if err = k.cdc.Unmarshal(value, &timeslice); err != nil {
@@ -545,6 +578,20 @@ func (k Keeper) DequeueAllMatureUBDQueue(ctx context.Context, currTime time.Time
 			return matureUnbonds, err
 		}
 
+		unbondingTimesliceIterator.Next()
+		if unbondingTimesliceIterator.Valid() {
+			nextHead = unbondingTimesliceIterator.Key()
+		} else {
+			nextHead = nil
+		}
+	}
+
+	if nextHead != nil {
+		if err = store.Set(types.UBDQueueHeadKey, nextHead); err != nil {
+			return matureUnbonds, err
+		}
+	} else {
+		_ = store.Delete(types.UBDQueueHeadKey)
 	}
 
 	return matureUnbonds, nil
@@ -794,13 +841,22 @@ func (k Keeper) GetRedelegationQueueTimeSlice(ctx context.Context, timestamp tim
 }
 
 // SetRedelegationQueueTimeSlice sets a specific redelegation queue timeslice.
+// Updates RedelegationQueueHeadKey when this timeslice is earlier than the current queue head.
 func (k Keeper) SetRedelegationQueueTimeSlice(ctx context.Context, timestamp time.Time, keys []types.DVVTriplet) error {
 	store := k.storeService.OpenKVStore(ctx)
+	key := types.GetRedelegationTimeKey(timestamp)
 	bz, err := k.cdc.Marshal(&types.DVVTriplets{Triplets: keys})
 	if err != nil {
 		return err
 	}
-	return store.Set(types.GetRedelegationTimeKey(timestamp), bz)
+	if err = store.Set(key, bz); err != nil {
+		return err
+	}
+	headVal, _ := store.Get(types.RedelegationQueueHeadKey)
+	if len(headVal) == 0 || bytes.Compare(key, headVal) < 0 {
+		return store.Set(types.RedelegationQueueHeadKey, key)
+	}
+	return nil
 }
 
 // InsertRedelegationQueue insert an redelegation delegation to the appropriate
@@ -825,19 +881,43 @@ func (k Keeper) InsertRedelegationQueue(ctx context.Context, red types.Redelegat
 }
 
 // RedelegationQueueIterator returns all the redelegation queue timeslices from
-// time 0 until endTime.
+// the queue head (or prefix start) until endTime. When RedelegationQueueHeadKey is set,
+// iteration starts from that key to avoid scanning from time 0 each block.
 func (k Keeper) RedelegationQueueIterator(ctx context.Context, endTime time.Time) (storetypes.Iterator, error) {
 	store := k.storeService.OpenKVStore(ctx)
-	return store.Iterator(types.RedelegationQueueKey, storetypes.InclusiveEndBytes(types.GetRedelegationTimeKey(endTime)))
+	endKey := storetypes.InclusiveEndBytes(types.GetRedelegationTimeKey(endTime))
+	headVal, err := store.Get(types.RedelegationQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.RedelegationQueueKey) {
+		headTime, err := sdk.ParseTimeBytes(headVal[len(types.RedelegationQueueKey):])
+		if err == nil && !headTime.After(endTime) {
+			return store.Iterator(headVal, endKey)
+		}
+	}
+	return store.Iterator(types.RedelegationQueueKey, endKey)
 }
 
 // DequeueAllMatureRedelegationQueue returns a concatenated list of all the
 // timeslices inclusively previous to currTime, and deletes the timeslices from
-// the queue.
+// the queue. Updates RedelegationQueueHeadKey so the next block can start
+// iteration from the new head instead of from the prefix start.
 func (k Keeper) DequeueAllMatureRedelegationQueue(ctx context.Context, currTime time.Time) (matureRedelegations []types.DVVTriplet, err error) {
 	store := k.storeService.OpenKVStore(ctx)
 
-	// gets an iterator for all timeslices from time 0 until the current Blockheader time
+	// Early exit when no mature entries: if queue head is after currTime, skip iterator entirely.
+	headVal, err := store.Get(types.RedelegationQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.RedelegationQueueKey) {
+		headTime, err := sdk.ParseTimeBytes(headVal[len(types.RedelegationQueueKey):])
+		if err == nil && headTime.After(currTime) {
+			return nil, nil
+		}
+	}
+
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	redelegationTimesliceIterator, err := k.RedelegationQueueIterator(ctx, sdkCtx.HeaderInfo().Time)
 	if err != nil {
@@ -845,7 +925,8 @@ func (k Keeper) DequeueAllMatureRedelegationQueue(ctx context.Context, currTime 
 	}
 	defer redelegationTimesliceIterator.Close()
 
-	for ; redelegationTimesliceIterator.Valid(); redelegationTimesliceIterator.Next() {
+	var nextHead []byte
+	for redelegationTimesliceIterator.Valid() {
 		timeslice := types.DVVTriplets{}
 		value := redelegationTimesliceIterator.Value()
 		if err = k.cdc.Unmarshal(value, &timeslice); err != nil {
@@ -857,6 +938,21 @@ func (k Keeper) DequeueAllMatureRedelegationQueue(ctx context.Context, currTime 
 		if err = store.Delete(redelegationTimesliceIterator.Key()); err != nil {
 			return nil, err
 		}
+
+		redelegationTimesliceIterator.Next()
+		if redelegationTimesliceIterator.Valid() {
+			nextHead = redelegationTimesliceIterator.Key()
+		} else {
+			nextHead = nil
+		}
+	}
+
+	if nextHead != nil {
+		if err = store.Set(types.RedelegationQueueHeadKey, nextHead); err != nil {
+			return matureRedelegations, err
+		}
+	} else {
+		_ = store.Delete(types.RedelegationQueueHeadKey)
 	}
 
 	return matureRedelegations, nil

--- a/x/staking/keeper/historical_info.go
+++ b/x/staking/keeper/historical_info.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 
 	storetypes "cosmossdk.io/store/types"
@@ -27,7 +28,8 @@ func (k Keeper) GetHistoricalInfo(ctx context.Context, height int64) (types.Hist
 	return types.UnmarshalHistoricalInfo(k.cdc, value)
 }
 
-// SetHistoricalInfo sets the historical info at a given height
+// SetHistoricalInfo sets the historical info at a given height. When the min-height
+// hint is unset (e.g. genesis), sets it to this height so IterateHistoricalInfo is bounded.
 func (k Keeper) SetHistoricalInfo(ctx context.Context, height int64, hi *types.HistoricalInfo) error {
 	store := k.storeService.OpenKVStore(ctx)
 	key := types.GetHistoricalInfoKey(height)
@@ -35,7 +37,15 @@ func (k Keeper) SetHistoricalInfo(ctx context.Context, height int64, hi *types.H
 	if err != nil {
 		return err
 	}
-	return store.Set(key, value)
+	if err = store.Set(key, value); err != nil {
+		return err
+	}
+	if bz, _ := store.Get(types.HistoricalInfoMinHeightKey); len(bz) < 8 {
+		minHeightBz := make([]byte, 8)
+		binary.BigEndian.PutUint64(minHeightBz, uint64(height))
+		_ = store.Set(types.HistoricalInfoMinHeightKey, minHeightBz)
+	}
+	return nil
 }
 
 // DeleteHistoricalInfo deletes the historical info at a given height
@@ -48,10 +58,17 @@ func (k Keeper) DeleteHistoricalInfo(ctx context.Context, height int64) error {
 
 // IterateHistoricalInfo provides an iterator over all stored HistoricalInfo
 // objects. For each HistoricalInfo object, cb will be called. If the cb returns
-// true, the iterator will break and close.
+// true, the iterator will break and close. Uses HistoricalInfoMinHeightKey when
+// set to start from the minimum stored height instead of the prefix start.
 func (k Keeper) IterateHistoricalInfo(ctx context.Context, cb func(types.HistoricalInfo) bool) error {
 	store := k.storeService.OpenKVStore(ctx)
-	iterator, err := store.Iterator(types.HistoricalInfoKey, storetypes.PrefixEndBytes(types.HistoricalInfoKey))
+	endKey := storetypes.PrefixEndBytes(types.HistoricalInfoKey)
+	startKey := types.HistoricalInfoKey
+	if bz, err := store.Get(types.HistoricalInfoMinHeightKey); err == nil && len(bz) >= 8 {
+		minHeight := int64(binary.BigEndian.Uint64(bz))
+		startKey = types.GetHistoricalInfoKey(minHeight)
+	}
+	iterator, err := store.Iterator(startKey, endKey)
 	if err != nil {
 		return err
 	}
@@ -82,7 +99,8 @@ func (k Keeper) GetAllHistoricalInfo(ctx context.Context) ([]types.HistoricalInf
 }
 
 // TrackHistoricalInfo saves the latest historical-info and deletes the oldest
-// heights that are below pruning height
+// heights that are below pruning height. Updates HistoricalInfoMinHeightKey so
+// IterateHistoricalInfo can start from the minimum stored height.
 func (k Keeper) TrackHistoricalInfo(ctx context.Context) error {
 	entryNum, err := k.HistoricalEntries(ctx)
 	if err != nil {
@@ -90,6 +108,7 @@ func (k Keeper) TrackHistoricalInfo(ctx context.Context) error {
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	blockHeight := sdkCtx.BlockHeight()
 
 	// Prune store to ensure we only have parameter-defined historical entries.
 	// In most cases, this will involve removing a single historical entry.
@@ -98,7 +117,7 @@ func (k Keeper) TrackHistoricalInfo(ctx context.Context) error {
 	// Since the entries to be deleted are always in a continuous range, we can iterate
 	// over the historical entries starting from the most recent version to be pruned
 	// and then return at the first empty entry.
-	for i := sdkCtx.BlockHeight() - int64(entryNum); i >= 0; i-- {
+	for i := blockHeight - int64(entryNum); i >= 0; i-- {
 		_, err := k.GetHistoricalInfo(ctx, i)
 		if err != nil {
 			if errors.Is(err, types.ErrNoHistoricalInfo) {
@@ -116,6 +135,18 @@ func (k Keeper) TrackHistoricalInfo(ctx context.Context) error {
 		return nil
 	}
 
+	// Update min height so IterateHistoricalInfo can start from the oldest stored height.
+	minHeight := blockHeight - int64(entryNum) + 1
+	if minHeight < 0 {
+		minHeight = 0
+	}
+	minHeightBz := make([]byte, 8)
+	binary.BigEndian.PutUint64(minHeightBz, uint64(minHeight))
+	store := k.storeService.OpenKVStore(ctx)
+	if err = store.Set(types.HistoricalInfoMinHeightKey, minHeightBz); err != nil {
+		return err
+	}
+
 	// Create HistoricalInfo struct
 	lastVals, err := k.GetLastValidators(ctx)
 	if err != nil {
@@ -125,5 +156,5 @@ func (k Keeper) TrackHistoricalInfo(ctx context.Context) error {
 	historicalEntry := types.NewHistoricalInfo(sdkCtx.BlockHeader(), types.Validators{Validators: lastVals, ValidatorCodec: k.validatorAddressCodec}, k.PowerReduction(ctx))
 
 	// Set latest HistoricalInfo at current height
-	return k.SetHistoricalInfo(ctx, sdkCtx.BlockHeight(), &historicalEntry)
+	return k.SetHistoricalInfo(ctx, blockHeight, &historicalEntry)
 }

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -467,14 +467,23 @@ func (k Keeper) GetUnbondingValidators(ctx context.Context, endTime time.Time, e
 }
 
 // SetUnbondingValidatorsQueue sets a given slice of validator addresses into
-// the unbonding validator queue by a given height and time.
+// the unbonding validator queue by a given height and time. Updates
+// ValidatorQueueHeadKey when this (time, height) is earlier than the current head.
 func (k Keeper) SetUnbondingValidatorsQueue(ctx context.Context, endTime time.Time, endHeight int64, addrs []string) error {
 	store := k.storeService.OpenKVStore(ctx)
+	key := types.GetValidatorQueueKey(endTime, endHeight)
 	bz, err := k.cdc.Marshal(&types.ValAddresses{Addresses: addrs})
 	if err != nil {
 		return err
 	}
-	return store.Set(types.GetValidatorQueueKey(endTime, endHeight), bz)
+	if err = store.Set(key, bz); err != nil {
+		return err
+	}
+	headVal, _ := store.Get(types.ValidatorQueueHeadKey)
+	if len(headVal) == 0 || bytes.Compare(key, headVal) < 0 {
+		return store.Set(types.ValidatorQueueHeadKey, key)
+	}
+	return nil
 }
 
 // InsertUnbondingValidatorQueue inserts a given unbonding validator address into
@@ -529,11 +538,21 @@ func (k Keeper) DeleteValidatorQueue(ctx context.Context, val types.Validator) e
 	return k.SetUnbondingValidatorsQueue(ctx, val.UnbondingTime, val.UnbondingHeight, newAddrs)
 }
 
-// ValidatorQueueIterator returns an interator ranging over validators that are
+// ValidatorQueueIterator returns an iterator ranging over validators that are
 // unbonding whose unbonding completion occurs at the given height and time.
+// When ValidatorQueueHeadKey is set, iteration starts from that key to avoid
+// scanning from the prefix start each block.
 func (k Keeper) ValidatorQueueIterator(ctx context.Context, endTime time.Time, endHeight int64) (corestore.Iterator, error) {
 	store := k.storeService.OpenKVStore(ctx)
-	return store.Iterator(types.ValidatorQueueKey, storetypes.InclusiveEndBytes(types.GetValidatorQueueKey(endTime, endHeight)))
+	endKey := storetypes.InclusiveEndBytes(types.GetValidatorQueueKey(endTime, endHeight))
+	headVal, err := store.Get(types.ValidatorQueueHeadKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(headVal) > len(types.ValidatorQueueKey) && bytes.Compare(headVal, endKey) <= 0 {
+		return store.Iterator(headVal, endKey)
+	}
+	return store.Iterator(types.ValidatorQueueKey, endKey)
 }
 
 // UnbondAllMatureValidators unbonds all the mature unbonding validators that
@@ -542,6 +561,21 @@ func (k Keeper) UnbondAllMatureValidators(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	blockTime := sdkCtx.BlockTime()
 	blockHeight := sdkCtx.BlockHeight()
+
+	// Early exit when no mature entries: if queue head is after (blockTime, blockHeight), skip iterator.
+	store := k.storeService.OpenKVStore(ctx)
+	headVal, err := store.Get(types.ValidatorQueueHeadKey)
+	if err != nil {
+		return err
+	}
+	if len(headVal) > len(types.ValidatorQueueKey) {
+		headTime, headHeight, err := types.ParseValidatorQueueKey(headVal)
+		if err == nil {
+			if headHeight > blockHeight || (headHeight == blockHeight && headTime.After(blockTime)) {
+				return nil
+			}
+		}
+	}
 
 	// unbondingValIterator will contains all validator addresses indexed under
 	// the ValidatorQueueKey prefix. Note, the entire index key is composed as

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -549,8 +549,11 @@ func (k Keeper) ValidatorQueueIterator(ctx context.Context, endTime time.Time, e
 	if err != nil {
 		return nil, err
 	}
-	if len(headVal) > len(types.ValidatorQueueKey) && bytes.Compare(headVal, endKey) <= 0 {
-		return store.Iterator(headVal, endKey)
+	// Only use headVal as start key if it looks like a full validator queue key (avoids panic on stale/corrupt values).
+	if len(headVal) >= types.ValidatorQueueKeyMinParseLength && bytes.Compare(headVal, endKey) <= 0 {
+		if _, _, parseErr := types.ParseValidatorQueueKey(headVal); parseErr == nil {
+			return store.Iterator(headVal, endKey)
+		}
 	}
 	return store.Iterator(types.ValidatorQueueKey, endKey)
 }
@@ -563,14 +566,15 @@ func (k Keeper) UnbondAllMatureValidators(ctx context.Context) error {
 	blockHeight := sdkCtx.BlockHeight()
 
 	// Early exit when no mature entries: if queue head is after (blockTime, blockHeight), skip iterator.
+	// Only use headVal if it looks like a full validator queue key (avoids panic on stale/corrupt 8-byte values).
 	store := k.storeService.OpenKVStore(ctx)
 	headVal, err := store.Get(types.ValidatorQueueHeadKey)
 	if err != nil {
 		return err
 	}
-	if len(headVal) > len(types.ValidatorQueueKey) {
-		headTime, headHeight, err := types.ParseValidatorQueueKey(headVal)
-		if err == nil {
+	if len(headVal) >= types.ValidatorQueueKeyMinParseLength {
+		headTime, headHeight, parseErr := types.ParseValidatorQueueKey(headVal)
+		if parseErr == nil {
 			if headHeight > blockHeight || (headHeight == blockHeight && headTime.After(blockTime)) {
 				return nil
 			}

--- a/x/staking/types/keys.go
+++ b/x/staking/types/keys.go
@@ -48,18 +48,18 @@ var (
 
 	UnbondingQueueKey    = []byte{0x41} // prefix for the timestamps in unbonding queue
 	RedelegationQueueKey = []byte{0x42} // prefix for the timestamps in redelegations queue
-	ValidatorQueueKey   = []byte{0x43} // prefix for the timestamps in validator queue
+	ValidatorQueueKey    = []byte{0x43} // prefix for the timestamps in validator queue
 
 	// Queue head keys: store the minimum (earliest) completion key in each queue.
 	// Used to start iteration from the head instead of prefix start, reducing EndBlock iterator cost.
 	// Value is the full queue key (e.g. GetUnbondingDelegationTimeKey(t)); 0x00 suffix ensures these sort before any real queue key.
-	UBDQueueHeadKey         = append(UnbondingQueueKey, 0x00)
+	UBDQueueHeadKey          = append(UnbondingQueueKey, 0x00)
 	RedelegationQueueHeadKey = append(RedelegationQueueKey, 0x00)
 	ValidatorQueueHeadKey    = append(ValidatorQueueKey, 0x00)
 
-	HistoricalInfoKey      = []byte{0x50} // prefix for the historical info
+	HistoricalInfoKey          = []byte{0x50}                    // prefix for the historical info
 	HistoricalInfoMinHeightKey = append(HistoricalInfoKey, 0x00) // stored min height for bounded iteration (value: 8-byte height)
-	ValidatorUpdatesKey    = []byte{0x61} // prefix for the end block validator updates key
+	ValidatorUpdatesKey        = []byte{0x61}                    // prefix for the end block validator updates key
 
 	ParamsKey = []byte{0x51} // prefix for parameters for module x/staking
 

--- a/x/staking/types/keys.go
+++ b/x/staking/types/keys.go
@@ -48,10 +48,18 @@ var (
 
 	UnbondingQueueKey    = []byte{0x41} // prefix for the timestamps in unbonding queue
 	RedelegationQueueKey = []byte{0x42} // prefix for the timestamps in redelegations queue
-	ValidatorQueueKey    = []byte{0x43} // prefix for the timestamps in validator queue
+	ValidatorQueueKey   = []byte{0x43} // prefix for the timestamps in validator queue
 
-	HistoricalInfoKey   = []byte{0x50} // prefix for the historical info
-	ValidatorUpdatesKey = []byte{0x61} // prefix for the end block validator updates key
+	// Queue head keys: store the minimum (earliest) completion key in each queue.
+	// Used to start iteration from the head instead of prefix start, reducing EndBlock iterator cost.
+	// Value is the full queue key (e.g. GetUnbondingDelegationTimeKey(t)); 0x00 suffix ensures these sort before any real queue key.
+	UBDQueueHeadKey         = append(UnbondingQueueKey, 0x00)
+	RedelegationQueueHeadKey = append(RedelegationQueueKey, 0x00)
+	ValidatorQueueHeadKey    = append(ValidatorQueueKey, 0x00)
+
+	HistoricalInfoKey      = []byte{0x50} // prefix for the historical info
+	HistoricalInfoMinHeightKey = append(HistoricalInfoKey, 0x00) // stored min height for bounded iteration (value: 8-byte height)
+	ValidatorUpdatesKey    = []byte{0x61} // prefix for the end block validator updates key
 
 	ParamsKey = []byte{0x51} // prefix for parameters for module x/staking
 

--- a/x/staking/types/keys.go
+++ b/x/staking/types/keys.go
@@ -57,6 +57,12 @@ var (
 	RedelegationQueueHeadKey = append(RedelegationQueueKey, 0x00)
 	ValidatorQueueHeadKey    = append(ValidatorQueueKey, 0x00)
 
+	// Pending times keys: store the sorted list of completion timestamps that have queue entries.
+	// Used to dequeue by point Get/Delete instead of a range iterator, avoiding expensive SST scans in LSM stores.
+	// Value: 4-byte count (big-endian uint32) + 8-byte UnixNano (big-endian int64) per time.
+	UBDPendingTimesKey          = append(UnbondingQueueKey, 0x01)
+	RedelegationPendingTimesKey = append(RedelegationQueueKey, 0x01)
+
 	HistoricalInfoKey          = []byte{0x50}                    // prefix for the historical info
 	HistoricalInfoMinHeightKey = append(HistoricalInfoKey, 0x00) // stored min height for bounded iteration (value: 8-byte height)
 	ValidatorUpdatesKey        = []byte{0x61}                    // prefix for the end block validator updates key
@@ -67,6 +73,14 @@ var (
 
 	// NOTE: keys in range 0x81–0x87 were previously used in liquid staking forks of the staking module.
 	// Module developers MUST NOT use these keys and MUST consider them "reserved".
+)
+
+// Validator queue key layout: prefix | timeBzLen (8 bytes) | timeBz | height (8 bytes).
+const (
+	validatorQueueKeyTimeBzLenSize = 8 // bytes for timeBz length (big-endian uint64)
+	validatorQueueKeyHeightSize    = 8 // bytes for height (big-endian uint64)
+	// ValidatorQueueKeyMinParseLength is the minimum length required to parse a validator queue key.
+	ValidatorQueueKeyMinParseLength = 1 + validatorQueueKeyTimeBzLenSize // len(ValidatorQueueKey) + timeBzLen size
 )
 
 // UnbondingType defines the type of unbonding operation
@@ -181,38 +195,45 @@ func GetValidatorQueueKey(timestamp time.Time, height int64) []byte {
 	timeBzL := len(timeBz)
 	prefixL := len(ValidatorQueueKey)
 
-	bz := make([]byte, prefixL+8+timeBzL+8)
+	bz := make([]byte, prefixL+validatorQueueKeyTimeBzLenSize+timeBzL+validatorQueueKeyHeightSize)
 
 	// copy the prefix
 	copy(bz[:prefixL], ValidatorQueueKey)
 
 	// copy the encoded time bytes length
-	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
+	copy(bz[prefixL:prefixL+validatorQueueKeyTimeBzLenSize], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 
 	// copy the encoded time bytes
-	copy(bz[prefixL+8:prefixL+8+timeBzL], timeBz)
+	copy(bz[prefixL+validatorQueueKeyTimeBzLenSize:prefixL+validatorQueueKeyTimeBzLenSize+timeBzL], timeBz)
 
 	// copy the encoded height
-	copy(bz[prefixL+8+timeBzL:], heightBz)
+	copy(bz[prefixL+validatorQueueKeyTimeBzLenSize+timeBzL:], heightBz)
 
 	return bz
 }
 
 // ParseValidatorQueueKey returns the encoded time and height from a key created
-// from GetValidatorQueueKey.
+// from GetValidatorQueueKey. Returns an error if bz is too short or malformed.
 func ParseValidatorQueueKey(bz []byte) (time.Time, int64, error) {
 	prefixL := len(ValidatorQueueKey)
+	if len(bz) < ValidatorQueueKeyMinParseLength {
+		return time.Time{}, 0, fmt.Errorf("invalid key length: %d", len(bz))
+	}
 	if prefix := bz[:prefixL]; !bytes.Equal(prefix, ValidatorQueueKey) {
 		return time.Time{}, 0, fmt.Errorf("invalid prefix; expected: %X, got: %X", ValidatorQueueKey, prefix)
 	}
 
-	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])
-	ts, err := sdk.ParseTimeBytes(bz[prefixL+8 : prefixL+8+int(timeBzL)])
+	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+validatorQueueKeyTimeBzLenSize])
+	minLen := prefixL + validatorQueueKeyTimeBzLenSize + int(timeBzL) + validatorQueueKeyHeightSize
+	if len(bz) < minLen {
+		return time.Time{}, 0, fmt.Errorf("invalid key length: %d (need %d for timeBzLen %d)", len(bz), minLen, timeBzL)
+	}
+	ts, err := sdk.ParseTimeBytes(bz[prefixL+validatorQueueKeyTimeBzLenSize : prefixL+validatorQueueKeyTimeBzLenSize+int(timeBzL)])
 	if err != nil {
 		return time.Time{}, 0, err
 	}
 
-	height := sdk.BigEndianToUint64(bz[prefixL+8+int(timeBzL):])
+	height := sdk.BigEndianToUint64(bz[prefixL+validatorQueueKeyTimeBzLenSize+int(timeBzL):])
 
 	return ts, int64(height), nil
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Summary

Reduces staking EndBlock (and BeginBlock historical info) cost when chain and queue data grow by avoiding full-prefix scans on time/height-ordered queues. Iterators now start from a tracked queue head (or, for HistoricalInfo, a min height) and can early-exit when there are no mature entries. 

## Problem 
Profiling showed bottlenecks in: 
- ValidatorQueueIterator 
- UBDQueueIterator 
- RedelegationQueueIterator 

Each was iterating from the prefix start (e.g. time 0) up to the current block time/height every block. As the chain and queues grew, that range and the cost of creating/using the iterator increased even when only a few entries matured per block.

## Solution

1) Queue head tracking (Validator, UBD, Redelegation) 

- Persist the minimum (earliest) completion key still in each queue. 
- Iteration: Start the iterator from this head key instead of the prefix start (fallback to prefix start if head is missing). 
- Early exit: If the stored head is after current block time/height, skip creating the iterator and return. 
- Head updates: 
      On enqueue (e.g. SetUBDQueueTimeSlice, SetRedelegationQueueTimeSlice, SetUnbondingValidatorsQueue): set head when the new key is earlier than the current head (or head is unset).

      On dequeue (UBD and Redelegation only): after removing mature timeslices, set head to the next remaining key, or clear head if the queue is empty. 
- Validator queue: head is updated only on enqueue; if the head key is later deleted, the next block’s iterator still starts at that key and the store seeks to the next existing key. 

2) HistoricalInfo (BeginBlock) 
- Persist the minimum stored height for historical info. 
- IterateHistoricalInfo: Start from GetHistoricalInfoKey(minHeight) when the min-height key is set. 
- TrackHistoricalInfo: After pruning, set the min-height key to blockHeight - entryNum + 1. 
- SetHistoricalInfo: When the min-height key is missing (e.g. genesis), set it to the current height so iteration is bounded from the first use.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
