### PR TITLE
fix(baseapp): close multistore opened for historical queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (cli) [#25485](https://github.com/cosmos/cosmos-sdk/pull/25485) Avoid failed to convert address field in `withdraw-validator-commission` cmd.
 * (baseapp) [#25642](https://github.com/cosmos/cosmos-sdk/pull/25642) Mark pre-block events for indexing based on local configuration.
 * (blockstm) [#1765](https://github.com/crypto-org-chain/cosmos-sdk/pull/1765) Remove `SigVerificationDecorator` signature incarnation cache causing state divergence under blockstm.
+* (baseapp) [#1808](https://github.com/crypto-org-chain/cosmos-sdk/pull/1808) Close multistore opened by `CacheMultiStoreWithVersion` after historical gRPC queries to prevent DB handle leaks.
 
 
 ## [v0.53.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.4) - 2025-07-25

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -16,6 +16,7 @@ import (
 
 	coreheader "cosmossdk.io/core/header"
 	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/log"
 	"cosmossdk.io/store/rootmulti"
 	snapshottypes "cosmossdk.io/store/snapshots/types"
 	storetypes "cosmossdk.io/store/types"
@@ -26,6 +27,22 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
+
+// closableMultiStore is optionally implemented by MultiStore backends that need
+// explicit resource cleanup after historical queries (e.g. releasing open DB handles).
+type closableMultiStore interface {
+	Close() error
+}
+
+// closeQueryMultiStore releases resources held by the multistore if it implements
+// closableMultiStore. Any close error is logged rather than silently dropped.
+func closeQueryMultiStore(logger log.Logger, ms storetypes.MultiStore) {
+	if c, ok := ms.(closableMultiStore); ok {
+		if err := c.Close(); err != nil {
+			logger.Error("failed to close query multistore", "err", err)
+		}
+	}
+}
 
 // Supported ABCI Query prefixes and paths
 const (
@@ -1172,6 +1189,11 @@ func (app *BaseApp) handleQueryGRPC(handler GRPCQueryHandler, req *abci.RequestQ
 		return sdkerrors.QueryResult(err, app.trace)
 	}
 
+	// Release resources held by the multistore opened for this historical query.
+	defer func() {
+		closeQueryMultiStore(app.logger, ctx.MultiStore())
+	}()
+
 	resp, err := handler(ctx, req)
 	if err != nil {
 		resp = sdkerrors.QueryResult(gRPCErrorToSDKError(err), app.trace)
@@ -1216,12 +1238,16 @@ func checkNegativeHeight(height int64) error {
 
 // CreateQueryContext creates a new sdk.Context for a query, taking as args
 // the block height and whether the query needs a proof or not.
+// If the returned context's MultiStore implements io.Closer, the caller is
+// responsible for closing it to release any resources (e.g. open DB handles).
 func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, error) {
 	return app.CreateQueryContextWithCheckHeader(height, prove, true)
 }
 
 // CreateQueryContextWithCheckHeader creates a new sdk.Context for a query, taking as args
 // the block height, whether the query needs a proof or not, and whether to check the header or not.
+// If the returned context's MultiStore implements io.Closer, the caller is
+// responsible for closing it to release any resources (e.g. open DB handles).
 func (app *BaseApp) CreateQueryContextWithCheckHeader(height int64, prove, checkHeader bool) (sdk.Context, error) {
 	if err := checkNegativeHeight(height); err != nil {
 		return sdk.Context{}, err

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -93,6 +93,11 @@ func (app *BaseApp) RegisterGRPCServerWithSkipCheckHeader(server gogogrpc.Server
 			}
 		}()
 
+		// Release resources held by the multistore opened for this historical query.
+		defer func() {
+			closeQueryMultiStore(app.logger, sdkCtx.MultiStore())
+		}()
+
 		return handler(grpcCtx, req)
 	}
 

--- a/baseapp/query_close_test.go
+++ b/baseapp/query_close_test.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
-	"github.com/stretchr/testify/require"
 )
 
 // mockClosableStore satisfies storetypes.MultiStore via embedding and adds Close().

--- a/baseapp/query_close_test.go
+++ b/baseapp/query_close_test.go
@@ -1,0 +1,52 @@
+package baseapp
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClosableStore satisfies storetypes.MultiStore via embedding and adds Close().
+type mockClosableStore struct {
+	storetypes.MultiStore
+	closeCalled bool
+	closeErr    error
+}
+
+func (m *mockClosableStore) Close() error {
+	m.closeCalled = true
+	return m.closeErr
+}
+
+// mockNonClosableStore satisfies storetypes.MultiStore but has no Close method.
+type mockNonClosableStore struct {
+	storetypes.MultiStore
+}
+
+func TestCloseQueryMultiStore(t *testing.T) {
+	t.Run("calls Close on a closable store", func(t *testing.T) {
+		ms := &mockClosableStore{}
+		closeQueryMultiStore(log.NewNopLogger(), ms)
+		require.True(t, ms.closeCalled)
+	})
+
+	t.Run("no-op for non-closable store", func(t *testing.T) {
+		ms := &mockNonClosableStore{}
+		require.NotPanics(t, func() {
+			closeQueryMultiStore(log.NewNopLogger(), ms)
+		})
+	})
+
+	t.Run("logs error when Close fails", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewLogger(&buf)
+		ms := &mockClosableStore{closeErr: errors.New("disk full")}
+		closeQueryMultiStore(logger, ms)
+		require.True(t, ms.closeCalled)
+		require.Contains(t, buf.String(), "disk full")
+	})
+}


### PR DESCRIPTION
CacheMultiStoreWithVersion can open DB handles that were never closed. Defer-close the multistore in both gRPC query paths to prevent handle leaks.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.  Your PR will not be merged unless you satisfy
all of these items.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

