### PR TITLE
feat(mempool): add multi-lane priority nonce mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-* (mempool) [#1811](https://github.com/crypto-org-chain/cosmos-sdk/pull/1811) Add `multi-lane-priority-nonce` mempool that indexes every `(signer, nonce)` lane from the configured `SignerExtractor`; new default when `mempool.max-txs >= 0`. Add `mempool.type` config field (`sender-nonce`, `priority-nonce`, `multi-lane-priority-nonce`).
+* (mempool) [#1811](https://github.com/crypto-org-chain/cosmos-sdk/pull/1811) Add multi-lane priority nonce mempool.
 * (crypto/ledger) [#25435](https://github.com/cosmos/cosmos-sdk/pull/25435) Add SetDERConversion to reset skipDERConversion and App name for ledger.
 * (gRPC) [#25565](https://github.com/cosmos/cosmos-sdk/pull/25565) Support for multi gRPC query clients serve with historical binaries to serve proper historical state.
 * (blockstm) [#25600](https://github.com/cosmos/cosmos-sdk/pull/25600) Allow dynamic retrieval of the coin denomination from multi store at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+* (mempool) [#1811](https://github.com/crypto-org-chain/cosmos-sdk/pull/1811) Add `multi-lane-priority-nonce` mempool that indexes every `(signer, nonce)` lane from the configured `SignerExtractor`; new default when `mempool.max-txs >= 0`. Add `mempool.type` config field (`sender-nonce`, `priority-nonce`, `multi-lane-priority-nonce`).
 * (crypto/ledger) [#25435](https://github.com/cosmos/cosmos-sdk/pull/25435) Add SetDERConversion to reset skipDERConversion and App name for ledger.
 * (gRPC) [#25565](https://github.com/cosmos/cosmos-sdk/pull/25565) Support for multi gRPC query clients serve with historical binaries to serve proper historical state.
 * (blockstm) [#25600](https://github.com/cosmos/cosmos-sdk/pull/25600) Allow dynamic retrieval of the coin denomination from multi store at runtime.

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -13,6 +13,7 @@ After completing this guide, applications will have:
 ## Table of Contents
 
 - [App Wiring Changes (REQUIRED)](#app-wiring-changes-required)
+- [Default Mempool Changed (REQUIRED)](#default-mempool-changed-required)
 - [Adding ProtocolPool Module (OPTIONAL)](#adding-protocolpool-module-optional)
   - [ProtocolPool Manual Wiring](#protocolpool-manual-wiring)
   - [ProtocolPool DI Wiring](#protocolpool-di-wiring)
@@ -32,6 +33,24 @@ app.ModuleManager.SetOrderPreBlockers(
     authtypes.ModuleName, // NEW
 )
 ```
+
+## Default Mempool Changed **REQUIRED**
+
+The default app-side mempool when `mempool.max-txs >= 0` has changed from
+`sender-nonce` to `multi-lane-priority-nonce`. If your chain used the previous
+default behavior, add the following to the `[mempool]` section of `app.toml` to
+preserve it:
+
+```toml
+[mempool]
+max-txs = 0    # or whatever value you had before
+type = "sender-nonce"
+```
+
+The new default (`multi-lane-priority-nonce`) indexes every `(signer, nonce)`
+lane from the configured `SignerExtractor`, enabling correct nonce tracking for
+transactions that contain multiple signers (e.g. EVM-compatible envelopes).
+Chains that use only single-signer transactions see no behavioral difference.
 
 ## Adding ProtocolPool Module **OPTIONAL**
 

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2420,7 +2420,7 @@ func TestOptimisticExecution(t *testing.T) {
 }
 
 func TestABCI_Proposal_FailReCheckTx(t *testing.T) {
-	pool := mempool.NewPriorityMempool[int64](mempool.PriorityNonceMempoolConfig[int64]{
+	pool := mempool.NewMultiLanePriorityMempool[int64](mempool.PriorityNonceMempoolConfig[int64]{
 		TxPriority:      mempool.NewDefaultTxPriority(),
 		MaxTx:           0,
 		SignerExtractor: mempool.NewDefaultSignerExtractionAdapter(),

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -671,7 +671,7 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_PriorityNonceMempoolTxSe
 		s.Run(name, func() {
 			ctrl := gomock.NewController(s.T())
 			app := mock.NewMockProposalTxVerifier(ctrl)
-			mp := mempool.NewPriorityMempool(
+			mp := mempool.NewMultiLanePriorityMempool(
 				mempool.PriorityNonceMempoolConfig[int64]{
 					TxPriority:      mempool.NewDefaultTxPriority(),
 					MaxTx:           0,

--- a/docs/docs/build/building-apps/02-app-mempool.md
+++ b/docs/docs/build/building-apps/02-app-mempool.md
@@ -28,8 +28,31 @@ Namely, the SDK provides the following mempools:
 * [No-op Mempool](#no-op-mempool)
 * [Sender Nonce Mempool](#sender-nonce-mempool)
 * [Priority Nonce Mempool](#priority-nonce-mempool)
+* [Multi-Lane Priority Nonce Mempool](#multi-lane-priority-nonce-mempool)
 
-By default, the SDK uses the [No-op Mempool](#no-op-mempool), but it can be replaced by the application developer in [`app.go`](./01-app-go-di.md):
+By default, when `mempool.max-txs >= 0` in `app.toml`, the SDK uses the
+[Multi-Lane Priority Nonce Mempool](#multi-lane-priority-nonce-mempool); when
+`mempool.max-txs < 0`, it uses the [No-op Mempool](#no-op-mempool). The mempool
+can also be selected from `app.toml` or replaced entirely in [`app.go`](./01-app-go-di.md).
+
+**Selecting via `app.toml`** — `server.DefaultBaseappOptions(appOpts)` (and the
+equivalent `server.MempoolBaseappOption(appOpts)`) reads the `[mempool]` section:
+
+```toml
+[mempool]
+# negative => no-op mempool, 0 => unbounded, positive => bounded.
+max-txs = 0
+# When max-txs >= 0:
+#   "" or "multi-lane-priority-nonce" (default)
+#   "sender-nonce"
+#   "priority-nonce"
+type = "multi-lane-priority-nonce"
+```
+
+The CLI exposes the same keys as `--mempool.max-txs` and `--mempool.type`.
+
+**Replacing in `app.go`** — instead of using the configured mempool, an
+application can wire its own implementation:
 
 ```go
 nonceMempool := mempool.NewSenderNonceMempool()
@@ -90,5 +113,55 @@ The priority nonce mempool provides mempool options allowing the application set
 
 * **OnRead**: Set a callback to be called when a transaction is read from the mempool.
 * **TxReplacement**: Sets a callback to be called when duplicated transaction nonce detected during mempool insert. Application can define a transaction replacement rule based on tx priority or certain transaction fields.
+
+### Multi-Lane Priority Nonce Mempool
+
+The multi-lane priority nonce mempool extends the [Priority Nonce Mempool](#priority-nonce-mempool)
+to index a transaction on **every** `(signer, nonce)` lane returned by the
+configured `SignerExtractor`, not only the first signer. This matches the
+semantics required when a single transaction affects multiple sender nonces
+(for example, an Ethermint envelope containing multiple `MsgEthereumTx`).
+
+This is the default mempool when `mempool.max-txs >= 0` and `mempool.type` is
+unset or set to `multi-lane-priority-nonce`.
+
+#### Behavior
+
+* **Insert**: every `(signer, nonce)` lane derived from `SignerExtractor` is
+  recorded. A transaction containing two lanes for the same `(signer, nonce)`
+  is rejected as duplicate. If any lane already has a transaction, the
+  configured `TxReplacement` callback is consulted on each conflicting lane;
+  failure on any single lane rejects the new transaction and leaves all
+  existing entries intact.
+* **Capacity**: when `MaxTx > 0`, the capacity check happens **after** lane
+  conflict detection, so a replacement that frees existing entries can succeed
+  even when the mempool is at capacity.
+* **Remove**: removes every lane the transaction occupies in a single
+  operation; partial removals are not possible.
+* **Select**: the iterator yields a transaction only when **all** of its lanes
+  are at the ready position of their respective sender indices. Multi-lane
+  transactions are emitted exactly once. A higher-priority transaction blocked
+  by a lower-nonce dependency on a non-anchor lane is deferred (not removed)
+  and revisited in priority order as cursors advance, so block construction
+  remains O(N) over the indexed lanes.
+
+#### Configuration
+
+Constructed via `mempool.NewMultiLanePriorityMempool(cfg)` and accepts the
+same `PriorityNonceMempoolConfig` (`TxPriority`, `MaxTx`, `SignerExtractor`,
+`TxReplacement`, `OnRead`) as the priority nonce mempool — see its [MaxTxs](#maxtxs-1)
+and [Callback](#callback) sections.
+
+#### When to use
+
+Use the multi-lane variant when:
+
+* the application uses a non-default `SignerExtractor` that returns multiple
+  signers per transaction (custom protocols, EVM compatibility), or
+* lane-aware capacity / replacement semantics across all signers are required.
+
+The original [Priority Nonce Mempool](#priority-nonce-mempool) only indexes
+the first signer's lane and remains available via `mempool.type = "priority-nonce"`
+for chains that prefer the historical behavior.
 
 More information on the SDK mempool implementation can be found in the [godocs](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types/mempool).

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -33,6 +33,16 @@ const (
 	DefaultGRPCMaxSendMsgSize = math.MaxInt32
 )
 
+// Built-in app-side mempool [mempool] type values in app.toml (when max-txs >= 0).
+const (
+	// MempoolTypeSenderNonce selects SenderNonceMempool (historical SDK node behavior).
+	MempoolTypeSenderNonce = "sender-nonce"
+	// MempoolTypePriorityNonce is PriorityNonceMempool (first signer lane only).
+	MempoolTypePriorityNonce = "priority-nonce"
+	// MempoolTypeMultiLanePriorityNonce is MultiLanePriorityNonceMempool (all signer lanes from SignerExtractor).
+	MempoolTypeMultiLanePriorityNonce = "multi-lane-priority-nonce"
+)
+
 // BaseConfig defines the server's basic configuration
 type BaseConfig struct {
 	// The minimum gas prices a validator is willing to accept for processing a
@@ -189,6 +199,9 @@ type MempoolConfig struct {
 	// unbounded in how many txs it may contain, and a positive value indicates
 	// the maximum amount of txs it may contain.
 	MaxTxs int `mapstructure:"max-txs"`
+	// Type selects the built-in mempool implementation when MaxTxs >= 0.
+	// Empty string defaults to MempoolTypeMultiLanePriorityNonce. See MempoolType* constants.
+	Type string `mapstructure:"type"`
 }
 
 // State Streaming configuration
@@ -288,6 +301,7 @@ func DefaultConfig() *Config {
 		},
 		Mempool: MempoolConfig{
 			MaxTxs: -1,
+			Type:   MempoolTypeMultiLanePriorityNonce,
 		},
 	}
 }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -250,9 +250,17 @@ stop-node-on-err = {{ .Streaming.ABCI.StopNodeOnErr }}
 # Setting max_txs to negative 1 (-1) will disable transactions from being inserted into the mempool (no-op mempool).
 # Setting max_txs to a positive number (> 0) will limit the number of transactions in the mempool, by the specified amount.
 #
+# When max-txs >= 0, type selects which SDK built-in app-side mempool to use:
+#   "" or "multi-lane-priority-nonce" (default) — MultiLanePriorityNonceMempool (priority; all signer lanes from SignerExtractor)
+#   "sender-nonce"                — SenderNonceMempool (historical SDK default behavior)
+#   "priority-nonce"              — PriorityNonceMempool (gas-price priority; first signer lane only)
+#
 # Note, this configuration only applies to SDK built-in app-side mempool
 # implementations.
 max-txs = {{ .Mempool.MaxTxs }}
+{{- if ne .Mempool.Type "" }}
+type = "{{ .Mempool.Type }}"
+{{- end }}
 `
 
 var configTemplate *template.Template

--- a/server/start.go
+++ b/server/start.go
@@ -102,6 +102,7 @@ const (
 
 	// mempool flags
 	FlagMempoolMaxTxs = "mempool.max-txs"
+	FlagMempoolType   = "mempool.type"
 
 	// testnet keys
 	KeyIsTestnet             = "is-testnet"
@@ -1008,6 +1009,8 @@ func addStartNodeFlags(cmd *cobra.Command, opts StartCmdOptions) {
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 	cmd.Flags().Bool(FlagDisableIAVLFastNode, false, "Disable fast node for IAVL tree")
 	cmd.Flags().Int(FlagMempoolMaxTxs, mempool.DefaultMaxTx, "Sets MaxTx value for the app-side mempool")
+	cmd.Flags().String(FlagMempoolType, serverconfig.MempoolTypeMultiLanePriorityNonce,
+		"Built-in app mempool when max-txs >= 0: multi-lane-priority-nonce (default), sender-nonce, priority-nonce")
 	cmd.Flags().Duration(FlagShutdownGrace, 0*time.Second, "On Shutdown, duration to wait for resource clean up")
 
 	// support old flags name for backwards compatibility

--- a/server/util.go
+++ b/server/util.go
@@ -518,22 +518,16 @@ func MempoolBaseappOption(appOpts types.AppOptions) func(*baseapp.BaseApp) {
 				mempool.SenderNonceMaxTxOpt(maxTxs),
 			),
 		)
-	case config.MempoolTypePriorityNonce:
-		return baseapp.SetMempool(
-			mempool.NewPriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
-				TxPriority:      mempool.NewDefaultTxPriority(),
-				MaxTx:           maxTxs,
-				SignerExtractor: mempool.NewDefaultSignerExtractionAdapter(),
-			}),
-		)
-	case config.MempoolTypeMultiLanePriorityNonce:
-		return baseapp.SetMempool(
-			mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
-				TxPriority:      mempool.NewDefaultTxPriority(),
-				MaxTx:           maxTxs,
-				SignerExtractor: mempool.NewDefaultSignerExtractionAdapter(),
-			}),
-		)
+	case config.MempoolTypePriorityNonce, config.MempoolTypeMultiLanePriorityNonce:
+		cfg := mempool.PriorityNonceMempoolConfig[int64]{
+			TxPriority:      mempool.NewDefaultTxPriority(),
+			MaxTx:           maxTxs,
+			SignerExtractor: mempool.NewDefaultSignerExtractionAdapter(),
+		}
+		if mempoolType == config.MempoolTypePriorityNonce {
+			return baseapp.SetMempool(mempool.NewPriorityMempool(cfg))
+		}
+		return baseapp.SetMempool(mempool.NewMultiLanePriorityMempool(cfg))
 	default:
 		panic(fmt.Sprintf("invalid app mempool type %q (from %s); valid: %q, %q, %q",
 			mempoolType, FlagMempoolType,

--- a/server/util.go
+++ b/server/util.go
@@ -496,6 +496,51 @@ func openTraceWriter(traceWriterFile string) (w io.WriteCloser, err error) {
 	)
 }
 
+// MempoolBaseappOption returns a BaseApp option that sets the app-side mempool from
+// mempool.max-txs and mempool.type (see server start flags). When mempool.max-txs is
+// unset in appOpts, it defaults to mempool.DefaultMaxTx (-1, no-op mempool).
+func MempoolBaseappOption(appOpts types.AppOptions) func(*baseapp.BaseApp) {
+	maxTxs := mempool.DefaultMaxTx
+	if v := appOpts.Get(FlagMempoolMaxTxs); v != nil {
+		maxTxs = cast.ToInt(v)
+	}
+	if maxTxs < 0 {
+		return baseapp.SetMempool(mempool.NoOpMempool{})
+	}
+	mempoolType := strings.ToLower(strings.TrimSpace(cast.ToString(appOpts.Get(FlagMempoolType))))
+	if mempoolType == "" {
+		mempoolType = config.MempoolTypeMultiLanePriorityNonce
+	}
+	switch mempoolType {
+	case config.MempoolTypeSenderNonce:
+		return baseapp.SetMempool(
+			mempool.NewSenderNonceMempool(
+				mempool.SenderNonceMaxTxOpt(maxTxs),
+			),
+		)
+	case config.MempoolTypePriorityNonce:
+		return baseapp.SetMempool(
+			mempool.NewPriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+				TxPriority:      mempool.NewDefaultTxPriority(),
+				MaxTx:           maxTxs,
+				SignerExtractor: mempool.NewDefaultSignerExtractionAdapter(),
+			}),
+		)
+	case config.MempoolTypeMultiLanePriorityNonce:
+		return baseapp.SetMempool(
+			mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+				TxPriority:      mempool.NewDefaultTxPriority(),
+				MaxTx:           maxTxs,
+				SignerExtractor: mempool.NewDefaultSignerExtractionAdapter(),
+			}),
+		)
+	default:
+		panic(fmt.Sprintf("invalid app mempool type %q (from %s); valid: %q, %q, %q",
+			mempoolType, FlagMempoolType,
+			config.MempoolTypeSenderNonce, config.MempoolTypePriorityNonce, config.MempoolTypeMultiLanePriorityNonce))
+	}
+}
+
 // DefaultBaseappOptions returns the default baseapp options provided by the Cosmos SDK
 func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 	var cache storetypes.MultiStorePersistentCache
@@ -540,15 +585,6 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 		cast.ToUint32(appOpts.Get(FlagStateSyncSnapshotKeepRecent)),
 	)
 
-	defaultMempool := baseapp.SetMempool(mempool.NoOpMempool{})
-	if maxTxs := cast.ToInt(appOpts.Get(FlagMempoolMaxTxs)); maxTxs >= 0 {
-		defaultMempool = baseapp.SetMempool(
-			mempool.NewSenderNonceMempool(
-				mempool.SenderNonceMaxTxOpt(maxTxs),
-			),
-		)
-	}
-
 	return []func(*baseapp.BaseApp){
 		baseapp.SetPruning(pruningOpts),
 		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(FlagMinGasPrices))),
@@ -562,7 +598,7 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(FlagIAVLCacheSize))),
 		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(FlagDisableIAVLFastNode))),
 		baseapp.SetIAVLSyncPruning(cast.ToBool(appOpts.Get(FlagIAVLSyncPruning))),
-		defaultMempool,
+		MempoolBaseappOption(appOpts),
 		baseapp.SetChainID(chainID),
 		baseapp.SetQueryGasLimit(cast.ToUint64(appOpts.Get(FlagQueryGasLimit))),
 	}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -11,14 +11,12 @@ import (
 	"testing"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
-	db "github.com/cosmos/cosmos-db"
+	dbm "github.com/cosmos/cosmos-db"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/log"
-
-	dbm "github.com/cosmos/cosmos-db"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -47,11 +45,11 @@ func preRunETestImpl(cmd *cobra.Command, args []string) error {
 
 func TestGetAppDBBackend(t *testing.T) {
 	v := viper.New()
-	require.Equal(t, server.GetAppDBBackend(v), db.GoLevelDBBackend)
+	require.Equal(t, server.GetAppDBBackend(v), dbm.GoLevelDBBackend)
 	v.Set("db_backend", "dbtype1") // value from CometBFT config
-	require.Equal(t, server.GetAppDBBackend(v), db.BackendType("dbtype1"))
+	require.Equal(t, server.GetAppDBBackend(v), dbm.BackendType("dbtype1"))
 	v.Set("app-db-backend", "dbtype2") // value from app.toml
-	require.Equal(t, server.GetAppDBBackend(v), db.BackendType("dbtype2"))
+	require.Equal(t, server.GetAppDBBackend(v), dbm.BackendType("dbtype2"))
 }
 
 func TestInterceptConfigsPreRunHandlerCreatesConfigFilesWhenMissing(t *testing.T) {

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -16,12 +16,18 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	"cosmossdk.io/log"
+
+	dbm "github.com/cosmos/cosmos-db"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/mempool"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
@@ -458,6 +464,61 @@ func TestEmptyMinGasPrices(t *testing.T) {
 	}
 	err = cmd.ExecuteContext(ctx)
 	require.Errorf(t, err, sdkerrors.ErrAppConfig.Error())
+}
+
+func TestMempoolBaseappOption(t *testing.T) {
+	encCfg := testutil.MakeTestEncodingConfig()
+	logger := log.NewNopLogger()
+
+	t.Run("unset max-txs defaults to no-op", func(t *testing.T) {
+		app := baseapp.NewBaseApp("t", logger, dbm.NewMemDB(), encCfg.TxConfig.TxDecoder(),
+			server.MempoolBaseappOption(mapGetter{}))
+		_, ok := app.Mempool().(mempool.NoOpMempool)
+		require.True(t, ok)
+	})
+
+	t.Run("max-txs -1 is no-op", func(t *testing.T) {
+		app := baseapp.NewBaseApp("t", logger, dbm.NewMemDB(), encCfg.TxConfig.TxDecoder(),
+			server.MempoolBaseappOption(mapGetter{server.FlagMempoolMaxTxs: -1}))
+		_, ok := app.Mempool().(mempool.NoOpMempool)
+		require.True(t, ok)
+	})
+
+	t.Run("max-txs 0 and empty type is multi-lane", func(t *testing.T) {
+		app := baseapp.NewBaseApp("t", logger, dbm.NewMemDB(), encCfg.TxConfig.TxDecoder(),
+			server.MempoolBaseappOption(mapGetter{server.FlagMempoolMaxTxs: 0}))
+		_, ok := app.Mempool().(*mempool.MultiLanePriorityNonceMempool[int64])
+		require.True(t, ok)
+	})
+
+	t.Run("sender-nonce", func(t *testing.T) {
+		app := baseapp.NewBaseApp("t", logger, dbm.NewMemDB(), encCfg.TxConfig.TxDecoder(),
+			server.MempoolBaseappOption(mapGetter{
+				server.FlagMempoolMaxTxs: 0,
+				server.FlagMempoolType:   config.MempoolTypeSenderNonce,
+			}))
+		_, ok := app.Mempool().(*mempool.SenderNonceMempool)
+		require.True(t, ok)
+	})
+
+	t.Run("priority-nonce", func(t *testing.T) {
+		app := baseapp.NewBaseApp("t", logger, dbm.NewMemDB(), encCfg.TxConfig.TxDecoder(),
+			server.MempoolBaseappOption(mapGetter{
+				server.FlagMempoolMaxTxs: 0,
+				server.FlagMempoolType:   config.MempoolTypePriorityNonce,
+			}))
+		_, ok := app.Mempool().(*mempool.PriorityNonceMempool[int64])
+		require.True(t, ok)
+	})
+
+	t.Run("invalid type panics", func(t *testing.T) {
+		require.Panics(t, func() {
+			server.MempoolBaseappOption(mapGetter{
+				server.FlagMempoolMaxTxs: 0,
+				server.FlagMempoolType:   "not-a-mempool-type",
+			})
+		})
+	})
 }
 
 type mapGetter map[string]any

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -243,6 +243,8 @@ func NewSimApp(
 	// }
 	// baseAppOptions = append(baseAppOptions, prepareOpt)
 
+	baseAppOptions = append([]func(*baseapp.BaseApp){server.MempoolBaseappOption(appOpts)}, baseAppOptions...)
+
 	// create and set dummy vote extension handler
 	voteExtOp := func(bApp *baseapp.BaseApp) {
 		voteExtHandler := NewVoteExtensionHandler()

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -243,6 +243,8 @@ func NewSimApp(
 	// }
 	// baseAppOptions = append(baseAppOptions, prepareOpt)
 
+	// Prepend so a caller-supplied mempool option at the end of baseAppOptions can
+	// still override (e.g. tests or custom app configs).
 	baseAppOptions = append([]func(*baseapp.BaseApp){server.MempoolBaseappOption(appOpts)}, baseAppOptions...)
 
 	// create and set dummy vote extension handler

--- a/simapp/app_di.go
+++ b/simapp/app_di.go
@@ -214,6 +214,8 @@ func NewSimApp(
 	// }
 	// baseAppOptions = append(baseAppOptions, prepareOpt)
 
+	// Prepend so a caller-supplied mempool option at the end of baseAppOptions can
+	// still override (e.g. tests or custom app configs).
 	baseAppOptions = append([]func(*baseapp.BaseApp){server.MempoolBaseappOption(appOpts)}, baseAppOptions...)
 
 	// create and set dummy vote extension handler

--- a/simapp/app_di.go
+++ b/simapp/app_di.go
@@ -214,6 +214,8 @@ func NewSimApp(
 	// }
 	// baseAppOptions = append(baseAppOptions, prepareOpt)
 
+	baseAppOptions = append([]func(*baseapp.BaseApp){server.MempoolBaseappOption(appOpts)}, baseAppOptions...)
+
 	// create and set dummy vote extension handler
 	voteExtOp := func(bApp *baseapp.BaseApp) {
 		voteExtHandler := NewVoteExtensionHandler()

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -157,7 +157,6 @@ func TestNewSimAppLoadsMempoolFromAppToml(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
 			configDir := filepath.Join(home, "config")

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -3,12 +3,15 @@ package simapp
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -24,11 +27,14 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/mempool"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -97,6 +103,82 @@ func TestSimAppExportAndBlockedAddrs(t *testing.T) {
 	app2 := NewSimApp(logger.With("instance", "second"), db, nil, true, simtestutil.NewAppOptionsWithFlagHome(t.TempDir()))
 	_, err = app2.ExportAppStateAndValidators(false, []string{}, []string{})
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
+}
+
+func TestNewSimAppLoadsMempoolFromAppToml(t *testing.T) {
+	logger := log.NewTestLogger(t)
+
+	testCases := []struct {
+		name        string
+		maxTxs      int
+		mempoolType string
+		assert      func(*testing.T, any)
+	}{
+		{
+			name:        "empty mempool type defaults to multi-lane",
+			maxTxs:      0,
+			mempoolType: "",
+			assert: func(t *testing.T, mp any) {
+				t.Helper()
+				_, ok := mp.(*mempool.MultiLanePriorityNonceMempool[int64])
+				require.True(t, ok)
+			},
+		},
+		{
+			name:        "sender nonce mempool",
+			maxTxs:      0,
+			mempoolType: config.MempoolTypeSenderNonce,
+			assert: func(t *testing.T, mp any) {
+				t.Helper()
+				_, ok := mp.(*mempool.SenderNonceMempool)
+				require.True(t, ok)
+			},
+		},
+		{
+			name:        "priority nonce mempool",
+			maxTxs:      0,
+			mempoolType: config.MempoolTypePriorityNonce,
+			assert: func(t *testing.T, mp any) {
+				t.Helper()
+				_, ok := mp.(*mempool.PriorityNonceMempool[int64])
+				require.True(t, ok)
+			},
+		},
+		{
+			name:        "negative max txs disables mempool",
+			maxTxs:      -1,
+			mempoolType: config.MempoolTypeSenderNonce,
+			assert: func(t *testing.T, mp any) {
+				t.Helper()
+				_, ok := mp.(mempool.NoOpMempool)
+				require.True(t, ok)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			configDir := filepath.Join(home, "config")
+			require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+			appCfg := config.DefaultConfig()
+			appCfg.Mempool.MaxTxs = tc.maxTxs
+			appCfg.Mempool.Type = tc.mempoolType
+
+			appTomlPath := filepath.Join(configDir, "app.toml")
+			config.WriteConfigFile(appTomlPath, appCfg)
+
+			appOpts := viper.New()
+			appOpts.SetConfigFile(appTomlPath)
+			require.NoError(t, appOpts.ReadInConfig())
+			appOpts.Set(flags.FlagHome, home)
+
+			app := NewSimApp(logger.With("case", tc.name), dbm.NewMemDB(), nil, true, appOpts)
+			tc.assert(t, app.Mempool())
+		})
+	}
 }
 
 func TestRunMigrations(t *testing.T) {

--- a/simapp/simd/cmd/commands.go
+++ b/simapp/simd/cmd/commands.go
@@ -222,14 +222,17 @@ func appExport(
 	appOpts = viperAppOpts
 
 	var simApp *simapp.SimApp
+	// Only wire mempool from app config for export; avoid snapshot/genesis parsing and
+	// other DefaultBaseappOptions side effects unrelated to state export.
+	mempoolOpt := server.MempoolBaseappOption(appOpts)
 	if height != -1 {
-		simApp = simapp.NewSimApp(logger, db, traceStore, false, appOpts)
+		simApp = simapp.NewSimApp(logger, db, traceStore, false, appOpts, mempoolOpt)
 
 		if err := simApp.LoadHeight(height); err != nil {
 			return servertypes.ExportedApp{}, err
 		}
 	} else {
-		simApp = simapp.NewSimApp(logger, db, traceStore, true, appOpts)
+		simApp = simapp.NewSimApp(logger, db, traceStore, true, appOpts, mempoolOpt)
 	}
 
 	return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)

--- a/types/mempool/export_test.go
+++ b/types/mempool/export_test.go
@@ -1,0 +1,29 @@
+package mempool
+
+import "fmt"
+
+// IsMultiLaneEmpty is a test helper that verifies all internal data structures
+// of a MultiLanePriorityNonceMempool are fully drained (no leaks after remove).
+func IsMultiLaneEmpty[C comparable](m Mempool) error {
+	mp := m.(*MultiLanePriorityNonceMempool[C])
+	if mp.priorityIndex.Len() != 0 {
+		return fmt.Errorf("priorityIndex not empty")
+	}
+	for k, v := range mp.priorityCounts {
+		if v != 0 {
+			return fmt.Errorf("priorityCounts not zero at %v, got %v", k, v)
+		}
+	}
+	for k, idx := range mp.senderIndices {
+		if idx.Len() != 0 {
+			return fmt.Errorf("senderIndex not empty for sender %v", k)
+		}
+	}
+	if len(mp.laneOwners) != 0 {
+		return fmt.Errorf("laneOwners not empty")
+	}
+	if len(mp.txLanes) != 0 {
+		return fmt.Errorf("txLanes not empty")
+	}
+	return nil
+}

--- a/types/mempool/priority_nonce_iterator_shared.go
+++ b/types/mempool/priority_nonce_iterator_shared.go
@@ -2,7 +2,7 @@ package mempool
 
 import "github.com/huandu/skiplist"
 
-func nextPriorityCursor[C comparable](current *skiplist.Element, index *skiplist.SkipList, minPriority C) (*skiplist.Element, string, C, bool) {
+func nextPriorityCursor[C comparable](current *skiplist.Element, index *skiplist.SkipList) (*skiplist.Element, string, bool) {
 	if current == nil {
 		current = index.Front()
 	} else {
@@ -10,14 +10,9 @@ func nextPriorityCursor[C comparable](current *skiplist.Element, index *skiplist
 	}
 
 	if current == nil {
-		return nil, "", minPriority, false
+		return nil, "", false
 	}
 
 	sender := current.Key().(txMeta[C]).sender
-	nextPriorityNode := current.Next()
-	if nextPriorityNode != nil {
-		return current, sender, nextPriorityNode.Key().(txMeta[C]).priority, true
-	}
-
-	return current, sender, minPriority, true
+	return current, sender, true
 }

--- a/types/mempool/priority_nonce_iterator_shared.go
+++ b/types/mempool/priority_nonce_iterator_shared.go
@@ -1,0 +1,32 @@
+package mempool
+
+import "github.com/huandu/skiplist"
+
+func nextPriorityCursor[C comparable](current *skiplist.Element, index *skiplist.SkipList, minPriority C) (*skiplist.Element, string, C, bool) {
+	if current == nil {
+		current = index.Front()
+	} else {
+		current = current.Next()
+	}
+
+	if current == nil {
+		return nil, "", minPriority, false
+	}
+
+	sender := current.Key().(txMeta[C]).sender
+	nextPriorityNode := current.Next()
+	if nextPriorityNode != nil {
+		return current, sender, nextPriorityNode.Key().(txMeta[C]).priority, true
+	}
+
+	return current, sender, minPriority, true
+}
+
+func nextSenderCursor(sender string, senderCursors map[string]*skiplist.Element, senderIndices map[string]*skiplist.SkipList) *skiplist.Element {
+	cursor, ok := senderCursors[sender]
+	if !ok {
+		return senderIndices[sender].Front()
+	}
+
+	return cursor.Next()
+}

--- a/types/mempool/priority_nonce_iterator_shared.go
+++ b/types/mempool/priority_nonce_iterator_shared.go
@@ -21,12 +21,3 @@ func nextPriorityCursor[C comparable](current *skiplist.Element, index *skiplist
 
 	return current, sender, minPriority, true
 }
-
-func nextSenderCursor(sender string, senderCursors map[string]*skiplist.Element, senderIndices map[string]*skiplist.SkipList) *skiplist.Element {
-	cursor, ok := senderCursors[sender]
-	if !ok {
-		return senderIndices[sender].Front()
-	}
-
-	return cursor.Next()
-}

--- a/types/mempool/priority_nonce_multilane.go
+++ b/types/mempool/priority_nonce_multilane.go
@@ -3,6 +3,7 @@ package mempool
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/huandu/skiplist"
@@ -31,8 +32,9 @@ type (
 		mempool       *MultiLanePriorityNonceMempool[C]
 		priorityNode  *skiplist.Element
 		senderCursors map[string]*skiplist.Element
-		sender        string
-		nextPriority  C
+		selected      Tx
+		deferred      map[multiLaneKey]struct{}
+		deferredIndex *skiplist.SkipList
 	}
 
 	multiLaneKey struct {
@@ -82,9 +84,7 @@ func (mp *MultiLanePriorityNonceMempool[C]) InsertWithGasWanted(ctx context.Cont
 	mp.mtx.Lock()
 	defer mp.mtx.Unlock()
 
-	if mp.cfg.MaxTx > 0 && mp.priorityIndex.Len() >= mp.cfg.MaxTx {
-		return ErrMempoolTxMaxCapacity
-	} else if mp.cfg.MaxTx < 0 {
+	if mp.cfg.MaxTx < 0 {
 		return nil
 	}
 
@@ -138,6 +138,12 @@ func (mp *MultiLanePriorityNonceMempool[C]) InsertWithGasWanted(ctx context.Cont
 		conflicts[conflictAnchor] = struct{}{}
 	}
 
+	// Replacement conflicts can free up existing entries and should count
+	// toward max-txs admission.
+	if mp.cfg.MaxTx > 0 && (mp.priorityIndex.Len()-len(conflicts)+1) > mp.cfg.MaxTx {
+		return ErrMempoolTxMaxCapacity
+	}
+
 	for conflict := range conflicts {
 		if err := mp.removeByAnchor(conflict); err != nil {
 			return err
@@ -171,50 +177,34 @@ func (mp *MultiLanePriorityNonceMempool[C]) Insert(ctx context.Context, tx sdk.T
 	return mp.InsertWithGasWanted(ctx, tx, gasLimit)
 }
 
-func (i *MultiLanePriorityNonceIterator[C]) iteratePriority() Iterator {
-	node, sender, nextPriority, ok := nextPriorityCursor(i.priorityNode, i.mempool.priorityIndex, i.mempool.cfg.TxPriority.MinValue)
-	if !ok {
-		return nil
-	}
-
-	i.priorityNode = node
-	i.sender = sender
-	i.nextPriority = nextPriority
-
-	return i.Next()
-}
-
 func (i *MultiLanePriorityNonceIterator[C]) Next() Iterator {
-	if i.priorityNode == nil {
+	if i.mempool == nil {
 		return nil
 	}
 
-	cursor := nextSenderCursor(i.sender, i.senderCursors, i.mempool.senderIndices)
-
-	if cursor == nil {
-		return i.iteratePriority()
+	if i.selectFromDeferred() {
+		return i
 	}
 
-	key := cursor.Key().(txMeta[C])
-	if i.mempool.cfg.TxPriority.Compare(key.priority, i.nextPriority) < 0 {
-		return i.iteratePriority()
-	} else if i.priorityNode.Next() != nil && i.mempool.cfg.TxPriority.Compare(key.priority, i.nextPriority) == 0 {
-		score, ok := i.mempool.scoreForLane(multiLaneKey{sender: key.sender, nonce: key.nonce})
+	for {
+		node, sender, _, ok := nextPriorityCursor(i.priorityNode, i.mempool.priorityIndex, i.mempool.cfg.TxPriority.MinValue)
 		if !ok {
-			return i.iteratePriority()
+			return nil
+		}
+		i.priorityNode = node
+
+		anchor := multiLaneKey{sender: sender, nonce: node.Key().(txMeta[C]).nonce}
+
+		if i.trySelectAnchor(anchor) {
+			return i
 		}
 
-		if i.mempool.cfg.TxPriority.Compare(score.weight, i.priorityNode.Next().Key().(txMeta[C]).weight) < 0 {
-			return i.iteratePriority()
-		}
+		i.deferAnchor(anchor)
 	}
-
-	i.senderCursors[i.sender] = cursor
-	return i
 }
 
 func (i *MultiLanePriorityNonceIterator[C]) Tx() Tx {
-	return i.senderCursors[i.sender].Value.(Tx)
+	return i.selected
 }
 
 func (mp *MultiLanePriorityNonceMempool[C]) Select(ctx context.Context, txs [][]byte) Iterator {
@@ -233,9 +223,11 @@ func (mp *MultiLanePriorityNonceMempool[C]) doSelect(_ context.Context, _ [][]by
 	iterator := &MultiLanePriorityNonceIterator[C]{
 		mempool:       mp,
 		senderCursors: make(map[string]*skiplist.Element),
+		deferred:      make(map[multiLaneKey]struct{}),
+		deferredIndex: skiplist.New(skiplistComparable(mp.cfg.TxPriority)),
 	}
 
-	return iterator.iteratePriority()
+	return iterator.Next()
 }
 
 func (mp *MultiLanePriorityNonceMempool[C]) SelectBy(ctx context.Context, txs [][]byte, callback func(Tx) bool) {
@@ -348,16 +340,6 @@ func (mp *MultiLanePriorityNonceMempool[C]) insertTxLanes(lanes []multiLaneKey, 
 	return anchorElement
 }
 
-func (mp *MultiLanePriorityNonceMempool[C]) scoreForLane(lane multiLaneKey) (txMeta[C], bool) {
-	anchor := lane
-	if owner, ok := mp.laneOwners[lane]; ok {
-		anchor = owner
-	}
-
-	score, ok := mp.scores[multiLaneToMeta[C](anchor)]
-	return score, ok
-}
-
 func (mp *MultiLanePriorityNonceMempool[C]) getLaneTx(lane multiLaneKey, priority C) (sdk.Tx, error) {
 	senderIndex := mp.senderIndices[lane.sender]
 	if senderIndex == nil {
@@ -432,6 +414,98 @@ func newMultiLaneSenderIndex[C comparable]() *skiplist.SkipList {
 	return skiplist.New(skiplist.LessThanFunc(func(a, b any) int {
 		return skiplist.Uint64.Compare(b.(txMeta[C]).nonce, a.(txMeta[C]).nonce)
 	}))
+}
+
+func (i *MultiLanePriorityNonceIterator[C]) selectFromDeferred() bool {
+	for node := i.deferredIndex.Front(); node != nil; {
+		next := node.Next()
+		anchor := node.Value.(multiLaneKey)
+
+		if i.trySelectAnchor(anchor) {
+			i.deferredIndex.Remove(node.Key())
+			delete(i.deferred, anchor)
+			return true
+		}
+		node = next
+	}
+	return false
+}
+
+func (i *MultiLanePriorityNonceIterator[C]) trySelectAnchor(anchor multiLaneKey) bool {
+	lanes := i.mempool.txLanes[anchor]
+	if len(lanes) == 0 {
+		lanes = []multiLaneKey{anchor}
+	}
+
+	lanesBySender := make(map[string][]uint64, len(lanes))
+	for _, lane := range lanes {
+		lanesBySender[lane.sender] = append(lanesBySender[lane.sender], lane.nonce)
+	}
+
+	nextCursors := make(map[string]*skiplist.Element, len(lanesBySender))
+	for sender, nonces := range lanesBySender {
+		slices.Sort(nonces)
+		cursor := i.senderCursors[sender]
+		senderIndex := i.mempool.senderIndices[sender]
+		if senderIndex == nil {
+			return false
+		}
+
+		for _, nonce := range nonces {
+			if cursor == nil {
+				cursor = senderIndex.Front()
+			} else {
+				cursor = cursor.Next()
+			}
+			if cursor == nil {
+				return false
+			}
+
+			cursorKey := cursor.Key().(txMeta[C])
+			if cursorKey.sender != sender || cursorKey.nonce != nonce {
+				return false
+			}
+
+			owner, ok := i.mempool.laneOwners[multiLaneKey{sender: sender, nonce: nonce}]
+			if !ok || owner != anchor {
+				return false
+			}
+		}
+		nextCursors[sender] = cursor
+	}
+
+	for sender, cursor := range nextCursors {
+		i.senderCursors[sender] = cursor
+	}
+	i.selected = nextCursors[anchor.sender].Value.(Tx)
+	return true
+}
+
+func (i *MultiLanePriorityNonceIterator[C]) deferAnchor(anchor multiLaneKey) {
+	if _, ok := i.deferred[anchor]; ok {
+		return
+	}
+
+	key, ok := i.mempool.anchorPriorityKey(anchor)
+	if !ok {
+		return
+	}
+	i.deferredIndex.Set(key, anchor)
+	i.deferred[anchor] = struct{}{}
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) anchorPriorityKey(anchor multiLaneKey) (txMeta[C], bool) {
+	score, ok := mp.scores[multiLaneToMeta[C](anchor)]
+	if !ok {
+		var zero txMeta[C]
+		return zero, false
+	}
+	return txMeta[C]{
+		nonce:    anchor.nonce,
+		priority: score.priority,
+		sender:   anchor.sender,
+		weight:   score.weight,
+	}, true
 }
 
 func IsMultiLaneEmpty[C comparable](mempool Mempool) error {

--- a/types/mempool/priority_nonce_multilane.go
+++ b/types/mempool/priority_nonce_multilane.go
@@ -506,4 +506,3 @@ func (mp *MultiLanePriorityNonceMempool[C]) anchorPriorityKey(anchor multiLaneKe
 		weight:   score.weight,
 	}, true
 }
-

--- a/types/mempool/priority_nonce_multilane.go
+++ b/types/mempool/priority_nonce_multilane.go
@@ -1,0 +1,471 @@
+package mempool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/huandu/skiplist"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	_ ExtMempool = (*MultiLanePriorityNonceMempool[int64])(nil)
+	_ Iterator   = (*MultiLanePriorityNonceIterator[int64])(nil)
+)
+
+type (
+	MultiLanePriorityNonceMempool[C comparable] struct {
+		mtx            sync.Mutex
+		priorityIndex  *skiplist.SkipList
+		priorityCounts map[C]int
+		senderIndices  map[string]*skiplist.SkipList
+		scores         map[txMeta[C]]txMeta[C]
+		laneOwners     map[multiLaneKey]multiLaneKey
+		txLanes        map[multiLaneKey][]multiLaneKey
+		cfg            PriorityNonceMempoolConfig[C]
+	}
+
+	MultiLanePriorityNonceIterator[C comparable] struct {
+		mempool       *MultiLanePriorityNonceMempool[C]
+		priorityNode  *skiplist.Element
+		senderCursors map[string]*skiplist.Element
+		sender        string
+		nextPriority  C
+	}
+
+	multiLaneKey struct {
+		sender string
+		nonce  uint64
+	}
+)
+
+func NewMultiLanePriorityMempool[C comparable](cfg PriorityNonceMempoolConfig[C]) *MultiLanePriorityNonceMempool[C] {
+	if cfg.SignerExtractor == nil {
+		cfg.SignerExtractor = NewDefaultSignerExtractionAdapter()
+	}
+
+	return &MultiLanePriorityNonceMempool[C]{
+		priorityIndex:  skiplist.New(skiplistComparable(cfg.TxPriority)),
+		priorityCounts: make(map[C]int),
+		senderIndices:  make(map[string]*skiplist.SkipList),
+		scores:         make(map[txMeta[C]]txMeta[C]),
+		laneOwners:     make(map[multiLaneKey]multiLaneKey),
+		txLanes:        make(map[multiLaneKey][]multiLaneKey),
+		cfg:            cfg,
+	}
+}
+
+func DefaultMultiLanePriorityMempool() *MultiLanePriorityNonceMempool[int64] {
+	return NewMultiLanePriorityMempool(DefaultPriorityNonceMempoolConfig())
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) NextSenderTx(sender string) sdk.Tx {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+
+	senderIndex, ok := mp.senderIndices[sender]
+	if !ok {
+		return nil
+	}
+
+	cursor := senderIndex.Front()
+	if cursor == nil {
+		return nil
+	}
+
+	return cursor.Value.(Tx).Tx
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) InsertWithGasWanted(ctx context.Context, tx sdk.Tx, gasWanted uint64) error {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+
+	if mp.cfg.MaxTx > 0 && mp.priorityIndex.Len() >= mp.cfg.MaxTx {
+		return ErrMempoolTxMaxCapacity
+	} else if mp.cfg.MaxTx < 0 {
+		return nil
+	}
+
+	memTx := NewMempoolTx(tx, gasWanted)
+
+	sigs, err := mp.cfg.SignerExtractor.GetSigners(tx)
+	if err != nil {
+		return err
+	}
+	if len(sigs) == 0 {
+		return fmt.Errorf("tx must have at least one signer")
+	}
+
+	lanes, err := multiLaneSigners(sigs, tx)
+	if err != nil {
+		return err
+	}
+
+	anchor := lanes[0]
+	priority := mp.cfg.TxPriority.GetTxPriority(ctx, tx)
+	conflicts := make(map[multiLaneKey]struct{})
+	for _, lane := range lanes {
+		conflictAnchor, ok := mp.laneOwners[lane]
+		if !ok {
+			continue
+		}
+
+		oldScore, ok := mp.scores[multiLaneToMeta[C](conflictAnchor)]
+		if !ok {
+			return fmt.Errorf("tx score not found for lane %+v", lane)
+		}
+
+		if mp.cfg.TxReplacement != nil {
+			oldTx, err := mp.getLaneTx(lane, oldScore.priority)
+			if err != nil {
+				return err
+			}
+
+			if !mp.cfg.TxReplacement(oldScore.priority, priority, oldTx, tx) {
+				return fmt.Errorf(
+					"tx doesn't fit the replacement rule on lane %+v, oldPriority: %v, newPriority: %v, oldTx: %v, newTx: %v",
+					lane,
+					oldScore.priority,
+					priority,
+					oldTx,
+					tx,
+				)
+			}
+		}
+
+		conflicts[conflictAnchor] = struct{}{}
+	}
+
+	for conflict := range conflicts {
+		if err := mp.removeByAnchor(conflict); err != nil {
+			return err
+		}
+	}
+
+	anchorElement := mp.insertTxLanes(lanes, anchor, priority, memTx)
+
+	mp.priorityCounts[priority]++
+
+	anchorScoreKey := multiLaneToMeta[C](anchor)
+	anchorPriorityKey := txMeta[C]{
+		nonce:         anchor.nonce,
+		priority:      priority,
+		sender:        anchor.sender,
+		senderElement: anchorElement,
+	}
+	mp.scores[anchorScoreKey] = txMeta[C]{priority: priority}
+	mp.txLanes[anchor] = lanes
+	mp.priorityIndex.Set(anchorPriorityKey, tx)
+
+	return nil
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) Insert(ctx context.Context, tx sdk.Tx) error {
+	var gasLimit uint64
+	if gasTx, ok := tx.(GasTx); ok {
+		gasLimit = gasTx.GetGas()
+	}
+
+	return mp.InsertWithGasWanted(ctx, tx, gasLimit)
+}
+
+func (i *MultiLanePriorityNonceIterator[C]) iteratePriority() Iterator {
+	node, sender, nextPriority, ok := nextPriorityCursor(i.priorityNode, i.mempool.priorityIndex, i.mempool.cfg.TxPriority.MinValue)
+	if !ok {
+		return nil
+	}
+
+	i.priorityNode = node
+	i.sender = sender
+	i.nextPriority = nextPriority
+
+	return i.Next()
+}
+
+func (i *MultiLanePriorityNonceIterator[C]) Next() Iterator {
+	if i.priorityNode == nil {
+		return nil
+	}
+
+	cursor := nextSenderCursor(i.sender, i.senderCursors, i.mempool.senderIndices)
+
+	if cursor == nil {
+		return i.iteratePriority()
+	}
+
+	key := cursor.Key().(txMeta[C])
+	if i.mempool.cfg.TxPriority.Compare(key.priority, i.nextPriority) < 0 {
+		return i.iteratePriority()
+	} else if i.priorityNode.Next() != nil && i.mempool.cfg.TxPriority.Compare(key.priority, i.nextPriority) == 0 {
+		score, ok := i.mempool.scoreForLane(multiLaneKey{sender: key.sender, nonce: key.nonce})
+		if !ok {
+			return i.iteratePriority()
+		}
+
+		if i.mempool.cfg.TxPriority.Compare(score.weight, i.priorityNode.Next().Key().(txMeta[C]).weight) < 0 {
+			return i.iteratePriority()
+		}
+	}
+
+	i.senderCursors[i.sender] = cursor
+	return i
+}
+
+func (i *MultiLanePriorityNonceIterator[C]) Tx() Tx {
+	return i.senderCursors[i.sender].Value.(Tx)
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) Select(ctx context.Context, txs [][]byte) Iterator {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+	return mp.doSelect(ctx, txs)
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) doSelect(_ context.Context, _ [][]byte) Iterator {
+	if mp.priorityIndex.Len() == 0 {
+		return nil
+	}
+
+	mp.reorderPriorityTies()
+
+	iterator := &MultiLanePriorityNonceIterator[C]{
+		mempool:       mp,
+		senderCursors: make(map[string]*skiplist.Element),
+	}
+
+	return iterator.iteratePriority()
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) SelectBy(ctx context.Context, txs [][]byte, callback func(Tx) bool) {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+
+	iter := mp.doSelect(ctx, txs)
+	for iter != nil && callback(iter.Tx()) {
+		iter = iter.Next()
+	}
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) reorderPriorityTies() {
+	node := mp.priorityIndex.Front()
+
+	var reordering []reorderKey[C]
+	for node != nil {
+		key := node.Key().(txMeta[C])
+		if mp.priorityCounts[key.priority] > 1 {
+			newKey := key
+			newKey.weight = senderWeight(mp.cfg.TxPriority, key.senderElement)
+			reordering = append(reordering, reorderKey[C]{deleteKey: key, insertKey: newKey, tx: node.Value.(sdk.Tx)})
+		}
+		node = node.Next()
+	}
+
+	for _, k := range reordering {
+		mp.priorityIndex.Remove(k.deleteKey)
+		delete(mp.scores, txMeta[C]{nonce: k.deleteKey.nonce, sender: k.deleteKey.sender})
+		mp.priorityIndex.Set(k.insertKey, k.tx)
+		mp.scores[txMeta[C]{nonce: k.insertKey.nonce, sender: k.insertKey.sender}] = k.insertKey
+	}
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) CountTx() int {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+	return mp.priorityIndex.Len()
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) Remove(tx sdk.Tx) error {
+	sigs, err := mp.cfg.SignerExtractor.GetSigners(tx)
+	if err != nil {
+		return err
+	}
+	if len(sigs) == 0 {
+		return fmt.Errorf("attempted to remove a tx with no signatures")
+	}
+
+	lanes, err := multiLaneSigners(sigs, tx)
+	if err != nil {
+		return err
+	}
+
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+
+	for _, lane := range lanes {
+		anchor, ok := mp.laneOwners[lane]
+		if !ok {
+			continue
+		}
+		return mp.removeByAnchor(anchor)
+	}
+
+	return ErrTxNotFound
+}
+
+func multiLaneSigners(sigs []SignerData, tx sdk.Tx) ([]multiLaneKey, error) {
+	lanes := make([]multiLaneKey, 0, len(sigs))
+	seen := make(map[multiLaneKey]struct{}, len(sigs))
+	for _, sig := range sigs {
+		nonce, err := ChooseNonce(sig.Sequence, tx)
+		if err != nil {
+			return nil, err
+		}
+
+		lane := multiLaneKey{sender: sig.Signer.String(), nonce: nonce}
+		if _, exists := seen[lane]; exists {
+			return nil, fmt.Errorf("tx contains duplicate lane (%s, %d)", lane.sender, lane.nonce)
+		}
+		seen[lane] = struct{}{}
+		lanes = append(lanes, lane)
+	}
+	return lanes, nil
+}
+
+func multiLaneToMeta[C comparable](lane multiLaneKey) txMeta[C] {
+	return txMeta[C]{nonce: lane.nonce, sender: lane.sender}
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) insertTxLanes(lanes []multiLaneKey, anchor multiLaneKey, priority C, memTx Tx) *skiplist.Element {
+	var anchorElement *skiplist.Element
+	for _, lane := range lanes {
+		senderIndex := mp.senderIndices[lane.sender]
+		if senderIndex == nil {
+			senderIndex = newMultiLaneSenderIndex[C]()
+			mp.senderIndices[lane.sender] = senderIndex
+		}
+
+		key := txMeta[C]{nonce: lane.nonce, priority: priority, sender: lane.sender}
+		el := senderIndex.Set(key, memTx)
+		if lane == anchor {
+			anchorElement = el
+		}
+
+		mp.laneOwners[lane] = anchor
+	}
+
+	return anchorElement
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) scoreForLane(lane multiLaneKey) (txMeta[C], bool) {
+	anchor := lane
+	if owner, ok := mp.laneOwners[lane]; ok {
+		anchor = owner
+	}
+
+	score, ok := mp.scores[multiLaneToMeta[C](anchor)]
+	return score, ok
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) getLaneTx(lane multiLaneKey, priority C) (sdk.Tx, error) {
+	senderIndex := mp.senderIndices[lane.sender]
+	if senderIndex == nil {
+		return nil, fmt.Errorf("sender %s not found", lane.sender)
+	}
+
+	key := txMeta[C]{nonce: lane.nonce, priority: priority, sender: lane.sender}
+	el := senderIndex.Get(key)
+	if el == nil {
+		return nil, fmt.Errorf("tx not found on lane (%s, %d)", lane.sender, lane.nonce)
+	}
+
+	return el.Value.(Tx).Tx, nil
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) removeByAnchor(anchor multiLaneKey) error {
+	scoreKey := multiLaneToMeta[C](anchor)
+	score, ok := mp.scores[scoreKey]
+	if !ok {
+		return ErrTxNotFound
+	}
+
+	lanes := mp.txLanes[anchor]
+	if len(lanes) == 0 {
+		lanes = []multiLaneKey{anchor}
+	}
+
+	for _, lane := range lanes {
+		if err := mp.removeLane(lane, score.priority); err != nil {
+			return err
+		}
+
+		delete(mp.laneOwners, lane)
+	}
+
+	priorityKey := txMeta[C]{
+		nonce:    anchor.nonce,
+		priority: score.priority,
+		sender:   anchor.sender,
+		weight:   score.weight,
+	}
+	mp.priorityIndex.Remove(priorityKey)
+	delete(mp.scores, scoreKey)
+	delete(mp.txLanes, anchor)
+
+	mp.priorityCounts[score.priority]--
+	if mp.priorityCounts[score.priority] == 0 {
+		delete(mp.priorityCounts, score.priority)
+	}
+
+	return nil
+}
+
+func (mp *MultiLanePriorityNonceMempool[C]) removeLane(lane multiLaneKey, priority C) error {
+	senderTxs := mp.senderIndices[lane.sender]
+	if senderTxs == nil {
+		return fmt.Errorf("sender %s not found", lane.sender)
+	}
+
+	key := txMeta[C]{nonce: lane.nonce, priority: priority, sender: lane.sender}
+	if senderTxs.Remove(key) == nil {
+		return ErrTxNotFound
+	}
+	if senderTxs.Len() == 0 {
+		delete(mp.senderIndices, lane.sender)
+	}
+
+	return nil
+}
+
+func newMultiLaneSenderIndex[C comparable]() *skiplist.SkipList {
+	return skiplist.New(skiplist.LessThanFunc(func(a, b any) int {
+		return skiplist.Uint64.Compare(b.(txMeta[C]).nonce, a.(txMeta[C]).nonce)
+	}))
+}
+
+func IsMultiLaneEmpty[C comparable](mempool Mempool) error {
+	mp := mempool.(*MultiLanePriorityNonceMempool[C])
+	if mp.priorityIndex.Len() != 0 {
+		return fmt.Errorf("priorityIndex not empty")
+	}
+
+	countKeys := make([]C, 0, len(mp.priorityCounts))
+	for k := range mp.priorityCounts {
+		countKeys = append(countKeys, k)
+	}
+	for _, k := range countKeys {
+		if mp.priorityCounts[k] != 0 {
+			return fmt.Errorf("priorityCounts not zero at %v, got %v", k, mp.priorityCounts[k])
+		}
+	}
+
+	senderKeys := make([]string, 0, len(mp.senderIndices))
+	for k := range mp.senderIndices {
+		senderKeys = append(senderKeys, k)
+	}
+	for _, k := range senderKeys {
+		if mp.senderIndices[k].Len() != 0 {
+			return fmt.Errorf("senderIndex not empty for sender %v", k)
+		}
+	}
+
+	if len(mp.laneOwners) != 0 {
+		return fmt.Errorf("laneOwners not empty")
+	}
+	if len(mp.txLanes) != 0 {
+		return fmt.Errorf("txLanes not empty")
+	}
+
+	return nil
+}

--- a/types/mempool/priority_nonce_multilane.go
+++ b/types/mempool/priority_nonce_multilane.go
@@ -3,6 +3,7 @@ package mempool
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 
@@ -103,7 +104,7 @@ func (mp *MultiLanePriorityNonceMempool[C]) InsertWithGasWanted(ctx context.Cont
 		return err
 	}
 
-	anchor := lanes[0]
+	anchor := lanes[0] // first signer is the priority-index representative
 	priority := mp.cfg.TxPriority.GetTxPriority(ctx, tx)
 	conflicts := make(map[multiLaneKey]struct{})
 	for _, lane := range lanes {
@@ -187,7 +188,7 @@ func (i *MultiLanePriorityNonceIterator[C]) Next() Iterator {
 	}
 
 	for {
-		node, sender, _, ok := nextPriorityCursor(i.priorityNode, i.mempool.priorityIndex, i.mempool.cfg.TxPriority.MinValue)
+		node, sender, ok := nextPriorityCursor[C](i.priorityNode, i.mempool.priorityIndex)
 		if !ok {
 			return nil
 		}
@@ -474,9 +475,7 @@ func (i *MultiLanePriorityNonceIterator[C]) trySelectAnchor(anchor multiLaneKey)
 		nextCursors[sender] = cursor
 	}
 
-	for sender, cursor := range nextCursors {
-		i.senderCursors[sender] = cursor
-	}
+	maps.Copy(i.senderCursors, nextCursors)
 	i.selected = nextCursors[anchor.sender].Value.(Tx)
 	return true
 }
@@ -508,38 +507,3 @@ func (mp *MultiLanePriorityNonceMempool[C]) anchorPriorityKey(anchor multiLaneKe
 	}, true
 }
 
-func IsMultiLaneEmpty[C comparable](mempool Mempool) error {
-	mp := mempool.(*MultiLanePriorityNonceMempool[C])
-	if mp.priorityIndex.Len() != 0 {
-		return fmt.Errorf("priorityIndex not empty")
-	}
-
-	countKeys := make([]C, 0, len(mp.priorityCounts))
-	for k := range mp.priorityCounts {
-		countKeys = append(countKeys, k)
-	}
-	for _, k := range countKeys {
-		if mp.priorityCounts[k] != 0 {
-			return fmt.Errorf("priorityCounts not zero at %v, got %v", k, mp.priorityCounts[k])
-		}
-	}
-
-	senderKeys := make([]string, 0, len(mp.senderIndices))
-	for k := range mp.senderIndices {
-		senderKeys = append(senderKeys, k)
-	}
-	for _, k := range senderKeys {
-		if mp.senderIndices[k].Len() != 0 {
-			return fmt.Errorf("senderIndex not empty for sender %v", k)
-		}
-	}
-
-	if len(mp.laneOwners) != 0 {
-		return fmt.Errorf("laneOwners not empty")
-	}
-	if len(mp.txLanes) != 0 {
-		return fmt.Errorf("txLanes not empty")
-	}
-
-	return nil
-}

--- a/types/mempool/priority_nonce_multilane_test.go
+++ b/types/mempool/priority_nonce_multilane_test.go
@@ -1,0 +1,244 @@
+package mempool_test
+
+import (
+	"math/rand"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/mempool"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+)
+
+type laneSigner struct {
+	address sdk.AccAddress
+	nonce   uint64
+}
+
+type multiLaneSignerAdapter struct {
+	lanesByID map[int][]laneSigner
+}
+
+func (a multiLaneSignerAdapter) GetSigners(tx sdk.Tx) ([]mempool.SignerData, error) {
+	ttx, ok := tx.(testTx)
+	if !ok {
+		return mempool.NewDefaultSignerExtractionAdapter().GetSigners(tx)
+	}
+
+	lanes, ok := a.lanesByID[ttx.id]
+	if !ok {
+		return mempool.NewDefaultSignerExtractionAdapter().GetSigners(tx)
+	}
+
+	signers := make([]mempool.SignerData, 0, len(lanes))
+	for _, lane := range lanes {
+		signers = append(signers, mempool.NewSignerData(lane.address, lane.nonce))
+	}
+	return signers, nil
+}
+
+func TestMultiLanePriorityNonceMempool_InsertIndexesEveryLane(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(0)), 3)
+	sa := accounts[0].Address
+	sb := accounts[1].Address
+	sc := accounts[2].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	tx := testTx{id: 100, priority: 50, nonce: 1, address: sa}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				tx.id: {
+					{address: sa, nonce: 1},
+					{address: sb, nonce: 7},
+					{address: sc, nonce: 3},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(tx.priority), tx))
+	require.Equal(t, 1, pool.CountTx())
+	require.Equal(t, tx, pool.NextSenderTx(sa.String()))
+	require.Equal(t, tx, pool.NextSenderTx(sb.String()))
+	require.Equal(t, tx, pool.NextSenderTx(sc.String()))
+}
+
+func TestMultiLanePriorityNonceMempool_ReplacementAcrossLanes(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(1)), 2)
+	attacker := accounts[0].Address
+	victim := accounts[1].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	batchTx := testTx{id: 200, priority: 10, nonce: 1, address: attacker}
+	cancelTx := testTx{id: 201, priority: 11, nonce: 3, address: victim}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				batchTx.id: {
+					{address: attacker, nonce: 1},
+					{address: victim, nonce: 3},
+				},
+				cancelTx.id: {
+					{address: victim, nonce: 3},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(batchTx.priority), batchTx))
+	require.NoError(t, pool.Insert(ctx.WithPriority(cancelTx.priority), cancelTx))
+
+	require.Equal(t, 1, pool.CountTx())
+	require.Nil(t, pool.NextSenderTx(attacker.String()))
+	require.Equal(t, cancelTx, pool.NextSenderTx(victim.String()))
+}
+
+func TestMultiLanePriorityNonceMempool_ReplacementRejectsIfAnyLaneFails(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(2)), 4)
+	a := accounts[0].Address
+	b := accounts[1].Address
+	c := accounts[2].Address
+	d := accounts[3].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	txA := testTx{id: 300, priority: 100, nonce: 1, address: a}
+	txB := testTx{id: 301, priority: 1, nonce: 1, address: b}
+	candidate := testTx{id: 302, priority: 50, nonce: 1, address: c}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		TxReplacement: func(op, np int64, _, _ sdk.Tx) bool {
+			return np > op
+		},
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				txA.id: {
+					{address: a, nonce: 1},
+				},
+				txB.id: {
+					{address: b, nonce: 1},
+				},
+				candidate.id: {
+					{address: a, nonce: 1},
+					{address: b, nonce: 1},
+					{address: d, nonce: 9},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(txA.priority), txA))
+	require.NoError(t, pool.Insert(ctx.WithPriority(txB.priority), txB))
+	err := pool.Insert(ctx.WithPriority(candidate.priority), candidate)
+	require.Error(t, err)
+
+	require.Equal(t, 2, pool.CountTx())
+	require.Equal(t, txA, pool.NextSenderTx(a.String()))
+	require.Equal(t, txB, pool.NextSenderTx(b.String()))
+}
+
+func TestMultiLanePriorityNonceMempool_RemoveCleansAllLanes(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(3)), 2)
+	sa := accounts[0].Address
+	sb := accounts[1].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	tx := testTx{id: 400, priority: 22, nonce: 1, address: sa}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				tx.id: {
+					{address: sa, nonce: 1},
+					{address: sb, nonce: 5},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(tx.priority), tx))
+	require.NoError(t, pool.Remove(tx))
+	require.Equal(t, 0, pool.CountTx())
+	require.Nil(t, pool.NextSenderTx(sa.String()))
+	require.Nil(t, pool.NextSenderTx(sb.String()))
+	require.NoError(t, mempool.IsMultiLaneEmpty[int64](pool))
+}
+
+func TestMultiLanePriorityNonceMempool_DuplicateLaneInTxRejected(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(4)), 1)
+	sa := accounts[0].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	tx := testTx{id: 500, priority: 5, nonce: 1, address: sa}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				tx.id: {
+					{address: sa, nonce: 1},
+					{address: sa, nonce: 1},
+				},
+			},
+		},
+	})
+
+	err := pool.Insert(ctx.WithPriority(tx.priority), tx)
+	require.ErrorContains(t, err, "duplicate lane")
+}
+
+func TestMultiLanePriorityNonceMempool_SelectTieUsesAnchorWeightForNonAnchorLane(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(5)), 3)
+	a := accounts[0].Address
+	b := accounts[1].Address
+	c := accounts[2].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	txAB := testTx{id: 600, priority: 10, nonce: 0, address: a}  // anchor sender A, also lane on B
+	txB := testTx{id: 601, priority: 10, nonce: 1, address: b}   // anchor sender B
+	txC := testTx{id: 602, priority: 10, nonce: 0, address: c}   // anchor sender C
+	txA2 := testTx{id: 603, priority: -10, nonce: 1, address: a} // gives txAB weight -10
+	txB2 := testTx{id: 604, priority: 2, nonce: 2, address: b}   // gives txB weight 2
+	txC2 := testTx{id: 605, priority: -1, nonce: 1, address: c}  // gives txC weight -1
+
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				txAB.id: {
+					{address: a, nonce: 0},
+					{address: b, nonce: 0},
+				},
+				txB.id: {
+					{address: b, nonce: 1},
+				},
+				txC.id: {
+					{address: c, nonce: 0},
+				},
+				txA2.id: {
+					{address: a, nonce: 1},
+				},
+				txB2.id: {
+					{address: b, nonce: 2},
+				},
+				txC2.id: {
+					{address: c, nonce: 1},
+				},
+			},
+		},
+	})
+
+	for _, tx := range []testTx{txAB, txB, txC, txA2, txB2, txC2} {
+		require.NoError(t, pool.Insert(ctx.WithPriority(tx.priority), tx))
+	}
+
+	iter := pool.Select(ctx, nil)
+	require.NotNil(t, iter)
+	first := iter.Tx().Tx.(testTx)
+	require.Equal(t, txC.id, first.id)
+}

--- a/types/mempool/priority_nonce_multilane_test.go
+++ b/types/mempool/priority_nonce_multilane_test.go
@@ -242,3 +242,147 @@ func TestMultiLanePriorityNonceMempool_SelectTieUsesAnchorWeightForNonAnchorLane
 	first := iter.Tx().Tx.(testTx)
 	require.Equal(t, txC.id, first.id)
 }
+
+func TestMultiLanePriorityNonceMempool_SelectDefersUntilAllLanesReady(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(6)), 2)
+	a := accounts[0].Address
+	b := accounts[1].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	txAB := testTx{id: 700, priority: 100, nonce: 1, address: a} // blocked on B nonce gap
+	txB1 := testTx{id: 701, priority: 10, nonce: 1, address: b}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				txAB.id: {
+					{address: a, nonce: 1},
+					{address: b, nonce: 2},
+				},
+				txB1.id: {
+					{address: b, nonce: 1},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(txAB.priority), txAB))
+	require.NoError(t, pool.Insert(ctx.WithPriority(txB1.priority), txB1))
+
+	iter := pool.Select(ctx, nil)
+	require.NotNil(t, iter)
+	first := iter.Tx().Tx.(testTx)
+	require.Equal(t, txB1.id, first.id)
+
+	iter = iter.Next()
+	require.NotNil(t, iter)
+	second := iter.Tx().Tx.(testTx)
+	require.Equal(t, txAB.id, second.id)
+}
+
+func TestMultiLanePriorityNonceMempool_SelectEmitsEachTxOnce(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(7)), 2)
+	a := accounts[0].Address
+	b := accounts[1].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	txAB := testTx{id: 710, priority: 50, nonce: 1, address: a}
+	txB2 := testTx{id: 711, priority: 40, nonce: 2, address: b}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				txAB.id: {
+					{address: a, nonce: 1},
+					{address: b, nonce: 1},
+				},
+				txB2.id: {
+					{address: b, nonce: 2},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(txAB.priority), txAB))
+	require.NoError(t, pool.Insert(ctx.WithPriority(txB2.priority), txB2))
+
+	iter := pool.Select(ctx, nil)
+	require.NotNil(t, iter)
+	first := iter.Tx().Tx.(testTx)
+	require.Equal(t, txAB.id, first.id)
+
+	iter = iter.Next()
+	require.NotNil(t, iter)
+	second := iter.Tx().Tx.(testTx)
+	require.Equal(t, txB2.id, second.id)
+
+	require.Nil(t, iter.Next())
+}
+
+func TestMultiLanePriorityNonceMempool_ReplacementAllowedWhenFull(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(8)), 2)
+	a := accounts[0].Address
+	b := accounts[1].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	original := testTx{id: 720, priority: 1, nonce: 1, address: a}
+	replacement := testTx{id: 721, priority: 2, nonce: 1, address: b}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		MaxTx:      1,
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				original.id: {
+					{address: a, nonce: 1},
+					{address: b, nonce: 1},
+				},
+				replacement.id: {
+					{address: b, nonce: 1},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(original.priority), original))
+	require.NoError(t, pool.Insert(ctx.WithPriority(replacement.priority), replacement))
+
+	require.Equal(t, 1, pool.CountTx())
+	require.Nil(t, pool.NextSenderTx(a.String()))
+	require.Equal(t, replacement, pool.NextSenderTx(b.String()))
+}
+
+func TestMultiLanePriorityNonceMempool_SelectHandlesSameSenderMultipleLanes(t *testing.T) {
+	accounts := simtypes.RandomAccounts(rand.New(rand.NewSource(9)), 1)
+	a := accounts[0].Address
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+
+	txA12 := testTx{id: 730, priority: 100, nonce: 1, address: a}
+	txA3 := testTx{id: 731, priority: 90, nonce: 3, address: a}
+	pool := mempool.NewMultiLanePriorityMempool(mempool.PriorityNonceMempoolConfig[int64]{
+		TxPriority: mempool.NewDefaultTxPriority(),
+		SignerExtractor: multiLaneSignerAdapter{
+			lanesByID: map[int][]laneSigner{
+				txA12.id: {
+					{address: a, nonce: 1},
+					{address: a, nonce: 2},
+				},
+				txA3.id: {
+					{address: a, nonce: 3},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, pool.Insert(ctx.WithPriority(txA12.priority), txA12))
+	require.NoError(t, pool.Insert(ctx.WithPriority(txA3.priority), txA3))
+
+	iter := pool.Select(ctx, nil)
+	require.NotNil(t, iter)
+	first := iter.Tx().Tx.(testTx)
+	require.Equal(t, txA12.id, first.id)
+
+	iter = iter.Next()
+	require.NotNil(t, iter)
+	second := iter.Tx().Tx.(testTx)
+	require.Equal(t, txA3.id, second.id)
+}


### PR DESCRIPTION
## Summary

- Adds `MultiLanePriorityNonceMempool` — a mempool that partitions transactions into configurable priority lanes, each running an independent `PriorityNonceMempool`
- Wires new `mempool-type` config option in `server/config` and `simapp`; defaults to existing single-lane behavior
- Documents the multi-lane design and tests `app.toml` wiring in simapp

## Changes

| Area | What |
|------|------|
| `types/mempool/priority_nonce_multilane.go` | New `MultiLanePriorityNonceMempool` implementation |
| `types/mempool/priority_nonce_multilane_test.go` | Unit + integration tests |
| `server/config/config.go`, `toml.go` | `mempool-type` config field |
| `server/util.go` | `NewMempoolFromConfig` factory wiring |
| `simapp/` | Wire multi-lane mempool; `app_test.go` tests `app.toml` round-trip |
| `docs/` | Multi-lane mempool documentation |