### PR TITLE
ci(runner): revert to ubuntu latest

### DIFF
--- a/.github/workflows/build-simd-nightlies.yml
+++ b/.github/workflows/build-simd-nightlies.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     timeout-minutes: 15
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +66,7 @@ jobs:
   publish:
     timeout-minutes: 15
     needs: build
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go-arch: ["amd64", "arm64"] # drop 32 bit support for now (and maybe forever)
@@ -54,7 +54,7 @@ jobs:
         run: GOARCH=${{ matrix.go-arch }} make confix
 
   build-poa:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   remind:
     name: Changelog Reminder
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     # Skip draft PRs and PRs starting with: revert, test, chore, ci, docs, style, build, refactor
     if: ${{ !github.event.pull_request.draft && !contains(github.event.pull_request.title, 'revert') && !contains(github.event.pull_request.title, 'test') && !contains(github.event.pull_request.title, 'chore') && !contains(github.event.pull_request.title, 'ci') && !contains(github.event.pull_request.title, 'docs') && !contains(github.event.pull_request.title, 'style') && !contains(github.event.pull_request.title, 'build') && !contains(github.event.pull_request.title, 'refactor') }}
     steps:

--- a/.github/workflows/clean-action-artifacts.yml
+++ b/.github/workflows/clean-action-artifacts.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   remove-old-artifacts:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: github/issue-labeler@v3.4
         if: join(github.event.issue.labels) == ''

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
       statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v6.1.1
         id: lint_pr_title

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -5,7 +5,7 @@ on:
       - "docs/**"
 jobs:
   markdown-link-check:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: cd docs && sh ./pre.sh
@@ -16,7 +16,7 @@ jobs:
   sims-notify-failure:
     permissions:
       contents: none
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     if: ${{ failure() }}
     steps:
       - name: Notify Slack on failure

--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   go-mod-tidy:
     name: Check go mod tidy
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -33,7 +33,7 @@ jobs:
 
   generate-mocks:
     name: Check up to date mocks
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/proto-docker.yml
+++ b/.github/workflows/proto-docker.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -13,7 +13,7 @@
 
 # jobs:
 #   root:
-#     runs-on: depot-ubuntu-22.04-4
+#     runs-on: ubuntu-latest
 #     name: "Push to buf.build/cosmos/cosmos-sdk"
 #     steps:
 #       - uses: actions/checkout@v5

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   detect-proto-changes:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     outputs:
       sdk_proto_diff: ${{ steps.sdk_proto_diff.outputs.diff }}
       poa_proto_diff: ${{ steps.poa_proto_diff.outputs.diff }}
@@ -39,7 +39,7 @@ jobs:
   lint:
     needs: detect-proto-changes
     if: needs.detect-proto-changes.outputs.sdk_proto_diff == 'true'
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -51,7 +51,7 @@ jobs:
   break-check:
     needs: detect-proto-changes
     if: needs.detect-proto-changes.outputs.sdk_proto_diff == 'true'
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: bufbuild/buf-setup-action@v1.50.0
@@ -63,7 +63,7 @@ jobs:
   lint-poa:
     needs: detect-proto-changes
     if: needs.detect-proto-changes.outputs.poa_proto_diff == 'true'
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -75,7 +75,7 @@ jobs:
   break-check-poa:
     needs: detect-proto-changes
     if: needs.detect-proto-changes.outputs.poa_proto_diff == 'true'
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: bufbuild/buf-setup-action@v1.50.0

--- a/.github/workflows/sims-053.yml
+++ b/.github/workflows/sims-053.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-sims')"
     steps:
       - uses: actions/checkout@v6
@@ -29,7 +29,7 @@ jobs:
   install-runsim:
     permissions:
       contents: none
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/setup-go@v6
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-go-runsim-binary
 
   test-sim-import-export:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     needs: [build, install-runsim]
     timeout-minutes: 60
     steps:
@@ -64,7 +64,7 @@ jobs:
           make test-sim-import-export
 
   test-sim-after-import:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     needs: [build, install-runsim]
     steps:
       - uses: actions/checkout@v6
@@ -83,7 +83,7 @@ jobs:
           make test-sim-after-import
 
   test-sim-multi-seed-short:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     needs: [build, install-runsim]
     steps:
       - uses: actions/checkout@v6
@@ -106,7 +106,7 @@ jobs:
       contents: none
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     if: ${{ failure() }}
     steps:
       - name: Notify Slack on failure

--- a/.github/workflows/sims-nightly.yml
+++ b/.github/workflows/sims-nightly.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test-sim-multi-seed-long:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -30,7 +30,7 @@ jobs:
           make test-sim-multi-seed-long
 
   test-sim-import-export:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: none
     needs: [test-sim-multi-seed-long]
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     if: ${{ failure() }}
     steps:
       - name: Notify Slack on failure

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   setup:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     outputs:
       git_diff: ${{ steps.git_diff.outputs.diff }}
     steps:
@@ -52,7 +52,7 @@ jobs:
   test-sdk-system:
     needs: setup
     if: needs.setup.outputs.git_diff
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -77,7 +77,7 @@ jobs:
           if-no-files-found: ignore
 
   test-poa-system:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -100,7 +100,7 @@ jobs:
           make test-system
 
   test-group-system:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   split-test-files:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -45,7 +45,7 @@ jobs:
           path: ./pkgs.txt.part.03
 
   tests:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     needs: split-test-files
     strategy:
       fail-fast: false
@@ -84,7 +84,7 @@ jobs:
           path: ./${{ matrix.part }}profile.out
 
   test-integration:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -146,7 +146,7 @@ jobs:
           path: ./tests/e2e-profile.out
 
   repo-analysis:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     needs: [tests, test-integration, test-e2e, test-clientv2, test-core, test-depinject, test-errors, test-math, test-collections, test-cosmovisor, test-confix, test-store, test-log, test-poa]
     steps:
       - uses: actions/checkout@v6
@@ -269,7 +269,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-sim-nondeterminism:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -302,7 +302,7 @@ jobs:
   # They run when there is a diff in their respective directories.
 
   test-clientv2:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -330,7 +330,7 @@ jobs:
           path: ./client/v2/coverage.out
 
   test-core:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -358,7 +358,7 @@ jobs:
           path: ./core/coverage.out
 
   test-depinject:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -386,7 +386,7 @@ jobs:
           path: ./depinject/coverage.out
 
   test-errors:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -414,7 +414,7 @@ jobs:
           path: ./errors/coverage.out
 
   test-math:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -442,7 +442,7 @@ jobs:
           path: ./math/coverage.out
 
   test-collections:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -470,7 +470,7 @@ jobs:
           path: ./collections/coverage.out
 
   test-cosmovisor:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -498,7 +498,7 @@ jobs:
           path: ./tools/cosmovisor/coverage.out
 
   test-confix:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -526,7 +526,7 @@ jobs:
           path: ./tools/confix/coverage.out
 
   test-store:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -555,7 +555,7 @@ jobs:
           path: ./store/coverage.out
 
   test-log:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -587,7 +587,7 @@ jobs:
   #############################
 
   test-poa:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.  Your PR will not be merged unless you satisfy
all of these items.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

