### PR TITLE
feat(baseapp): run AnteHandler in default InsertTx handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* (baseapp) [#1815](https://github.com/crypto-org-chain/cosmos-sdk/pull/1815) Run `AnteHandler` in the default `InsertTx` ABCI handler. When no custom `InsertTxHandler` is registered, `BaseApp.InsertTx` now calls `RunTx(execModeCheck, ...)` so peer-relayed txs under `mempool.type=app` are validated (sigs, chain-id, nonce, fees) before admission instead of erroring with `"InsertTx handler not set"`. Apps with a custom `InsertTxHandler` keep their override.
+* (baseapp) [#1815](https://github.com/crypto-org-chain/cosmos-sdk/pull/1815) feat(baseapp): run AnteHandler in default InsertTx handler.
+
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (baseapp) [#1815](https://github.com/crypto-org-chain/cosmos-sdk/pull/1815) Run `AnteHandler` in the default `InsertTx` ABCI handler. When no custom `InsertTxHandler` is registered, `BaseApp.InsertTx` now calls `RunTx(execModeCheck, ...)` so peer-relayed txs under `mempool.type=app` are validated (sigs, chain-id, nonce, fees) before admission instead of erroring with `"InsertTx handler not set"`. Apps with a custom `InsertTxHandler` keep their override.
+
 ### Bug Fixes
 
 ### Deprecated

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -396,10 +396,36 @@ func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, er
 }
 
 // InsertTx inserts a tx into the applications mempool.
+//
+// When no custom InsertTxHandler is set, the default behavior runs the
+// configured AnteHandler chain via RunTx(execModeCheck, ...). RunTx admits
+// the tx into the mempool only when the AnteHandler succeeds, mirroring the
+// CheckTx ABCI path. This prevents peer-relayed admission of unverified txs
+// (bad signatures, replay/wrong-chainID, future-nonce flooding) under
+// mempool.type=app.
+//
+// Note on duplicates: the SDK's default mempools dedup by (sender, nonce)
+// via overwrite rather than tx-hash error. A tx that arrives via both the
+// RPC CheckTx path and a peer's InsertTx will run AnteHandler twice against
+// checkState. This is the same property CheckTx already has and is the
+// trade-off for validating before admission. If the AnteHandler is nil, the
+// default skips validation and admits the tx unchanged — register an
+// AnteHandler chain (or a custom InsertTxHandler) for production use.
 func (app *BaseApp) InsertTx(req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error) {
+	_, span := tracer.Start(context.Background(), "InsertTx", trace.WithAttributes(otelattr.String("ExecMode", "check")))
+	defer span.End()
+
 	if app.abciHandlers.InsertTxHandler == nil {
-		return nil, errors.New("InsertTx handler not set")
+		// ResponseInsertTx only carries Code, so gas/result/events from RunTx
+		// are intentionally discarded.
+		_, _, _, err := app.RunTx(execModeCheck, req.Tx, nil, -1, nil, nil)
+		if err != nil {
+			_, code, _ := errorsmod.ABCIInfo(err, app.trace)
+			return &abci.ResponseInsertTx{Code: code}, nil
+		}
+		return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
 	}
+
 	return app.abciHandlers.InsertTxHandler(req)
 }
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/mempool"
 )
 
 // Supported ABCI Query prefixes and paths
@@ -396,7 +397,7 @@ func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, er
 	return app.abciHandlers.CheckTxHandler(runTx, req)
 }
 
-// InsertTx inserts a tx into the applications mempool.
+// InsertTx inserts a tx into the application's mempool.
 //
 // When no custom InsertTxHandler is set, the default behavior runs the
 // configured AnteHandler chain via RunTx(execModeCheck, ...). RunTx admits
@@ -413,46 +414,52 @@ func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, er
 // default skips validation and admits the tx unchanged — register an
 // AnteHandler chain (or a custom InsertTxHandler) for production use.
 func (app *BaseApp) InsertTx(req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error) {
+	if app.abciHandlers.InsertTxHandler != nil {
+		return app.abciHandlers.InsertTxHandler(req)
+	}
+	return app.defaultInsertTx(req)
+}
+
+// defaultInsertTx is the built-in InsertTx implementation used when no custom
+// InsertTxHandler is registered. It deduplicates via a tx-hash seen-cache,
+// then runs RunTx(execModeCheck) to validate and admit the tx.
+//
+// CometBFT v0.39 AppReactor delivers gossiped txs via InsertTx with no
+// built-in dedup (the network-side cache lives in the flood mempool, which is
+// inactive under mempool.type=app). N peers gossiping the same tx would
+// otherwise trigger N full ECDSA-recover + state reads. The seen-cache
+// reproduces flood-mempool's tx-hash dedup at the app layer.
+func (app *BaseApp) defaultInsertTx(req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error) {
+	var hash [32]byte
+	if app.insertTxSeenCache != nil {
+		hash = sha256.Sum256(req.Tx)
+		if app.insertTxSeenCache.Has(hash) {
+			return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
+		}
+	}
+
+	// Span covers RunTx only; cache hits above are too cheap to trace.
+	// defer fires at function return — not block exit — intentional.
 	_, span := tracer.Start(context.Background(), "InsertTx", trace.WithAttributes(otelattr.String("ExecMode", "check")))
 	defer span.End()
 
-	if app.abciHandlers.InsertTxHandler == nil {
-		// Skip AnteHandler if we admitted this tx-hash recently. CometBFT v0.39
-		// AppReactor delivers gossiped txs via InsertTx, with no built-in
-		// dedup (the network-side cache lives in the flood mempool, which is
-		// inactive under mempool.type=app). N peers gossiping the same tx
-		// would otherwise trigger N full ECDSA-recover + state reads. The
-		// seen-cache reproduces flood-mempool's tx-hash dedup at the app
-		// layer; cache hits return CodeTypeOK without running RunTx because
-		// the original admission already inserted the tx into the mempool.
-		var hash [32]byte
-		if app.insertTxSeenCache != nil {
-			hash = sha256.Sum256(req.Tx)
-			if app.insertTxSeenCache.Has(hash) {
-				return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
-			}
+	// ResponseInsertTx only carries Code, so gas/result/events from RunTx
+	// are intentionally discarded.
+	_, _, _, err := app.RunTx(execModeCheck, req.Tx, nil, -1, nil, nil)
+	if err != nil {
+		// ErrMempoolTxMaxCapacity is transient — translate to CometBFT's
+		// CodeTypeRetry so the peer backs off and resubmits instead of
+		// dropping the tx as a permanent reject.
+		if errors.Is(err, mempool.ErrMempoolTxMaxCapacity) {
+			return &abci.ResponseInsertTx{Code: abci.CodeTypeRetry}, nil
 		}
-
-		// ResponseInsertTx only carries Code, so gas/result/events from RunTx
-		// are intentionally discarded.
-		_, _, _, err := app.RunTx(execModeCheck, req.Tx, nil, -1, nil, nil)
-		if err != nil {
-			// ErrMempoolIsFull is transient — translate to CometBFT's
-			// CodeTypeRetry so the peer backs off and resubmits instead of
-			// dropping the tx as a permanent reject.
-			if errors.Is(err, sdkerrors.ErrMempoolIsFull) {
-				return &abci.ResponseInsertTx{Code: abci.CodeTypeRetry}, nil
-			}
-			_, code, _ := errorsmod.ABCIInfo(err, app.trace)
-			return &abci.ResponseInsertTx{Code: code}, nil
-		}
-		if app.insertTxSeenCache != nil {
-			app.insertTxSeenCache.Add(hash)
-		}
-		return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
+		_, code, _ := errorsmod.ABCIInfo(err, app.trace)
+		return &abci.ResponseInsertTx{Code: code}, nil
 	}
-
-	return app.abciHandlers.InsertTxHandler(req)
+	if app.insertTxSeenCache != nil {
+		app.insertTxSeenCache.Add(hash)
+	}
+	return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
 }
 
 // ReapTxs returns new valid txs from the applications mempool.

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -420,6 +420,12 @@ func (app *BaseApp) InsertTx(req *abci.RequestInsertTx) (*abci.ResponseInsertTx,
 		// are intentionally discarded.
 		_, _, _, err := app.RunTx(execModeCheck, req.Tx, nil, -1, nil, nil)
 		if err != nil {
+			// ErrMempoolIsFull is transient — translate to CometBFT's
+			// CodeTypeRetry so the peer backs off and resubmits instead of
+			// dropping the tx as a permanent reject.
+			if errors.Is(err, sdkerrors.ErrMempoolIsFull) {
+				return &abci.ResponseInsertTx{Code: abci.CodeTypeRetry}, nil
+			}
 			_, code, _ := errorsmod.ABCIInfo(err, app.trace)
 			return &abci.ResponseInsertTx{Code: code}, nil
 		}

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -2,6 +2,7 @@ package baseapp
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strings"
@@ -416,6 +417,22 @@ func (app *BaseApp) InsertTx(req *abci.RequestInsertTx) (*abci.ResponseInsertTx,
 	defer span.End()
 
 	if app.abciHandlers.InsertTxHandler == nil {
+		// Skip AnteHandler if we admitted this tx-hash recently. CometBFT v0.39
+		// AppReactor delivers gossiped txs via InsertTx, with no built-in
+		// dedup (the network-side cache lives in the flood mempool, which is
+		// inactive under mempool.type=app). N peers gossiping the same tx
+		// would otherwise trigger N full ECDSA-recover + state reads. The
+		// seen-cache reproduces flood-mempool's tx-hash dedup at the app
+		// layer; cache hits return CodeTypeOK without running RunTx because
+		// the original admission already inserted the tx into the mempool.
+		var hash [32]byte
+		if app.insertTxSeenCache != nil {
+			hash = sha256.Sum256(req.Tx)
+			if app.insertTxSeenCache.Has(hash) {
+				return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
+			}
+		}
+
 		// ResponseInsertTx only carries Code, so gas/result/events from RunTx
 		// are intentionally discarded.
 		_, _, _, err := app.RunTx(execModeCheck, req.Tx, nil, -1, nil, nil)
@@ -428,6 +445,9 @@ func (app *BaseApp) InsertTx(req *abci.RequestInsertTx) (*abci.ResponseInsertTx,
 			}
 			_, code, _ := errorsmod.ABCIInfo(err, app.trace)
 			return &abci.ResponseInsertTx{Code: code}, nil
+		}
+		if app.insertTxSeenCache != nil {
+			app.insertTxSeenCache.Add(hash)
 		}
 		return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
 	}

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2701,3 +2701,130 @@ func TestABCI_Race_Commit_Query(t *testing.T) {
 
 	require.Equal(t, int64(1001), app.GetContextForCheckTx(nil).BlockHeight())
 }
+
+func TestABCI_InsertTx_DefaultRunsAnteHandler(t *testing.T) {
+	anteKey := []byte("ante-key")
+	deliverKey := []byte("deliver-key")
+	// SenderNonceMaxTxOpt required: DefaultMaxTx=-1 short-circuits Insert into a no-op.
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(5000))
+	anteOpt := func(bapp *baseapp.BaseApp) { bapp.SetAnteHandler(anteHandlerTxTest(t, capKey1, anteKey)) }
+	suite := NewBaseAppSuite(t, anteOpt, baseapp.SetMempool(pool))
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	tx := newTxCounter(t, suite.txConfig, 0, 0)
+	txBytes, err := suite.txConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	r, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.Equal(t, abci.CodeTypeOK, r.Code)
+
+	// AnteHandler ran and persisted to checkState (counter advanced from 0 to 1).
+	checkStateStore := getCheckStateCtx(suite.baseApp).KVStore(capKey1)
+	require.Equal(t, int64(1), getIntFromStore(t, checkStateStore, anteKey))
+
+	// Tx admitted to mempool.
+	require.Equal(t, 1, pool.CountTx())
+}
+
+func TestABCI_InsertTx_DefaultRejectsBadTx(t *testing.T) {
+	anteKey := []byte("ante-key")
+	deliverKey := []byte("deliver-key")
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(5000))
+	anteOpt := func(bapp *baseapp.BaseApp) { bapp.SetAnteHandler(anteHandlerTxTest(t, capKey1, anteKey)) }
+	suite := NewBaseAppSuite(t, anteOpt, baseapp.SetMempool(pool))
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	tx := newTxCounter(t, suite.txConfig, 0, 0)
+	tx = setFailOnAnte(t, suite.txConfig, tx, true)
+	txBytes, err := suite.txConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	r, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.Equal(t, sdkerrors.ErrUnauthorized.ABCICode(), r.Code,
+		"AnteHandler-failing tx must surface the ante's ABCI code")
+	require.Equal(t, 0, pool.CountTx(), "rejected tx must not enter mempool")
+}
+
+func TestABCI_InsertTx_DefaultDuplicateTx(t *testing.T) {
+	// The default mempools (PriorityNonce, SenderNonce) dedup by (sender, nonce)
+	// via overwrite, so a second InsertTx of the same (sender, nonce) still
+	// returns OK but must not double-count the mempool. Use a passthrough
+	// AnteHandler so the second pass isn't rejected by the test ante's
+	// counter-equality check.
+	deliverKey := []byte("deliver-key")
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(5000))
+	anteOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+			return ctx, nil
+		})
+	}
+	suite := NewBaseAppSuite(t, anteOpt, baseapp.SetMempool(pool))
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	tx := newTxCounter(t, suite.txConfig, 0, 0)
+	txBytes, err := suite.txConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	r1, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.Equal(t, abci.CodeTypeOK, r1.Code)
+	require.Equal(t, 1, pool.CountTx())
+
+	// Same tx bytes again: same (sender, nonce). SenderNonceMempool overwrites
+	// rather than erroring, so InsertTx returns OK and the count stays at 1.
+	r2, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.Equal(t, abci.CodeTypeOK, r2.Code)
+	require.Equal(t, 1, pool.CountTx(),
+		"duplicate (sender,nonce) must not grow the mempool")
+}
+
+func TestABCI_InsertTx_CustomHandlerOverridesDefault(t *testing.T) {
+	const customCode uint32 = 42
+	called := false
+
+	customHandler := func(req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error) {
+		called = true
+		return &abci.ResponseInsertTx{Code: customCode}, nil
+	}
+
+	deliverKey := []byte("deliver-key")
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(5000))
+	setupOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetAnteHandler(anteHandlerTxTest(t, capKey1, []byte("ante-key")))
+		bapp.SetInsertTxHandler(customHandler)
+	}
+	suite := NewBaseAppSuite(t, setupOpt, baseapp.SetMempool(pool))
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	tx := newTxCounter(t, suite.txConfig, 0, 0)
+	txBytes, err := suite.txConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	r, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.True(t, called, "custom InsertTxHandler must be invoked when set")
+	require.Equal(t, customCode, r.Code)
+}

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2765,8 +2765,10 @@ func TestABCI_InsertTx_DefaultDuplicateTx(t *testing.T) {
 	// counter-equality check.
 	deliverKey := []byte("deliver-key")
 	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(5000))
+	callCount := 0
 	anteOpt := func(bapp *baseapp.BaseApp) {
 		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+			callCount++
 			return ctx, nil
 		})
 	}
@@ -2786,14 +2788,51 @@ func TestABCI_InsertTx_DefaultDuplicateTx(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, abci.CodeTypeOK, r1.Code)
 	require.Equal(t, 1, pool.CountTx())
+	require.Equal(t, 1, callCount, "AnteHandler must run on first insert")
 
-	// Same tx bytes again: same (sender, nonce). SenderNonceMempool overwrites
-	// rather than erroring, so InsertTx returns OK and the count stays at 1.
+	// Same tx bytes again: seen-cache must short-circuit, AnteHandler must NOT run.
 	r2, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
 	require.NoError(t, err)
 	require.Equal(t, abci.CodeTypeOK, r2.Code)
 	require.Equal(t, 1, pool.CountTx(),
 		"duplicate (sender,nonce) must not grow the mempool")
+	require.Equal(t, 1, callCount, "seen-cache must skip AnteHandler on duplicate")
+}
+
+func TestABCI_InsertTx_DefaultMempoolFullRetry(t *testing.T) {
+	// Pool capacity = 1. First tx fills it; second must return CodeTypeRetry.
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(1))
+	anteOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+			return ctx, nil
+		})
+	}
+	suite := NewBaseAppSuite(t, anteOpt, baseapp.SetMempool(pool))
+	deliverKey := []byte("deliver-key")
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	// Fill the pool with seq=0.
+	tx0 := newTxCounter(t, suite.txConfig, 0, 0)
+	tx0Bytes, err := suite.txConfig.TxEncoder()(tx0)
+	require.NoError(t, err)
+	r0, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: tx0Bytes})
+	require.NoError(t, err)
+	require.Equal(t, abci.CodeTypeOK, r0.Code)
+	require.Equal(t, 1, pool.CountTx())
+
+	// Different tx (seq=1) hits full pool → must get CodeTypeRetry.
+	tx1 := newTxCounter(t, suite.txConfig, 1, 0)
+	tx1Bytes, err := suite.txConfig.TxEncoder()(tx1)
+	require.NoError(t, err)
+	r1, err := suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: tx1Bytes})
+	require.NoError(t, err)
+	require.Equal(t, abci.CodeTypeRetry, r1.Code,
+		"full mempool must surface CodeTypeRetry so the peer backs off")
 }
 
 func TestABCI_InsertTx_CustomHandlerOverridesDefault(t *testing.T) {
@@ -2827,4 +2866,38 @@ func TestABCI_InsertTx_CustomHandlerOverridesDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, called, "custom InsertTxHandler must be invoked when set")
 	require.Equal(t, customCode, r.Code)
+}
+
+func TestABCI_InsertTx_DefaultCacheDisabled(t *testing.T) {
+	// SetInsertTxSeenCacheSize(0) disables the seen-cache. Every InsertTx must
+	// run RunTx regardless of whether the same tx was admitted before.
+	callCount := 0
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(5000))
+	setupOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetInsertTxSeenCacheSize(0) // disable cache
+		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+			callCount++
+			return ctx, nil
+		})
+	}
+	suite := NewBaseAppSuite(t, setupOpt, baseapp.SetMempool(pool))
+	deliverKey := []byte("deliver-key")
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	tx := newTxCounter(t, suite.txConfig, 0, 0)
+	txBytes, err := suite.txConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	_, err = suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount)
+
+	_, err = suite.baseApp.InsertTx(&abci.RequestInsertTx{Tx: txBytes})
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "disabled cache must run AnteHandler on every call")
 }

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -192,6 +192,7 @@ func NewBaseApp(
 		sigverifyTx:          true,
 		gasConfig:            config.GasConfig{QueryGasLimit: math.MaxUint64},
 		disableBlockGasMeter: true,
+		insertTxCacheSizeHint: -1, // -1 = use default; 0 = disabled; >0 = explicit size
 	}
 
 	for _, option := range options {
@@ -240,9 +241,10 @@ func NewBaseApp(
 
 	app.stateManager = state.NewManager(app.gasConfig)
 
-	// Default cache size matches CometBFT's mempool cache_size default
-	// (10K) with headroom for high-fanout gossip windows.
-	if app.insertTxCacheSizeHint == 0 {
+	// 16384 ≈ 1.6× CometBFT's default mempool cache_size (10K), sized to
+	// absorb a gossip fan-out burst without evicting recently-admitted txs.
+	// hint=-1 means "not configured, use default"; 0 means "disabled".
+	if app.insertTxCacheSizeHint < 0 {
 		app.insertTxCacheSizeHint = 16384
 	}
 	if app.insertTxCacheSizeHint > 0 {
@@ -252,41 +254,53 @@ func NewBaseApp(
 	return app
 }
 
-// insertTxCache is a fixed-size FIFO of tx-hashes used by the default
-// InsertTx handler to skip AnteHandler runs on gossip fan-out duplicates.
-// Lookups go through sync.Map (lock-free reads); the eviction queue is
-// guarded by a small mutex so writers don't race the FIFO.
+// insertTxCache is a fixed-size FIFO ring buffer of tx-hashes used by the
+// default InsertTx handler to skip AnteHandler runs on gossip fan-out
+// duplicates. A plain map+RWMutex is used instead of sync.Map because
+// sync.Map performs poorly under high-churn workloads (every key is
+// eventually evicted). The ring buffer avoids the slice-growth churn of a
+// naive FIFO append+reslice.
 type insertTxCache struct {
-	max int
-	m   sync.Map // map[[32]byte]struct{}
-	mu  sync.Mutex
-	q   [][32]byte // FIFO of recent hashes
+	mu   sync.RWMutex
+	m    map[[32]byte]struct{}
+	q    [][32]byte // ring buffer, pre-allocated to len==max
+	head int        // next write index
+	full bool       // true once ring has wrapped
 }
 
 func newInsertTxCache(max int) *insertTxCache {
-	return &insertTxCache{max: max, q: make([][32]byte, 0, max)}
+	return &insertTxCache{
+		m: make(map[[32]byte]struct{}, max),
+		q: make([][32]byte, max),
+	}
 }
 
 // Has reports whether the tx-hash was admitted recently.
 func (c *insertTxCache) Has(h [32]byte) bool {
-	_, ok := c.m.Load(h)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.m[h]
 	return ok
 }
 
 // Add records a tx-hash, evicting the oldest entry if at capacity.
-// Safe for concurrent use; duplicates are no-ops.
+// Safe for concurrent use; duplicate adds are no-ops.
 func (c *insertTxCache) Add(h [32]byte) {
-	if _, loaded := c.m.LoadOrStore(h, struct{}{}); loaded {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.m[h]; ok {
 		return
 	}
-	c.mu.Lock()
-	c.q = append(c.q, h)
-	if len(c.q) > c.max {
-		evict := c.q[0]
-		c.q = c.q[1:]
-		c.m.Delete(evict)
+	if c.full {
+		delete(c.m, c.q[c.head])
 	}
-	c.mu.Unlock()
+	c.m[h] = struct{}{}
+	c.q[c.head] = h
+	c.head++
+	if c.head == len(c.q) {
+		c.head = 0
+		c.full = true
+	}
 }
 
 // Name returns the name of the BaseApp.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -81,6 +81,12 @@ type BaseApp struct {
 
 	abciHandlers sdk.ABCIHandlers
 
+	// insertTxSeenCache deduplicates AnteHandler invocations on gossip fan-out
+	// under mempool.type=app. Keyed by tx-hash; a hit short-circuits the
+	// default InsertTx handler. Set via SetInsertTxSeenCacheSize before sealing.
+	insertTxSeenCache     *insertTxCache
+	insertTxCacheSizeHint int
+
 	addrPeerFilter sdk.PeerFilter // filter peers by address and port
 	idPeerFilter   sdk.PeerFilter // filter peers by node ID
 	fauxMerkleMode bool           // if true, IAVL MountStores uses MountStoresDB for simulation speed.
@@ -234,7 +240,53 @@ func NewBaseApp(
 
 	app.stateManager = state.NewManager(app.gasConfig)
 
+	// Default cache size matches CometBFT's mempool cache_size default
+	// (10K) with headroom for high-fanout gossip windows.
+	if app.insertTxCacheSizeHint == 0 {
+		app.insertTxCacheSizeHint = 16384
+	}
+	if app.insertTxCacheSizeHint > 0 {
+		app.insertTxSeenCache = newInsertTxCache(app.insertTxCacheSizeHint)
+	}
+
 	return app
+}
+
+// insertTxCache is a fixed-size FIFO of tx-hashes used by the default
+// InsertTx handler to skip AnteHandler runs on gossip fan-out duplicates.
+// Lookups go through sync.Map (lock-free reads); the eviction queue is
+// guarded by a small mutex so writers don't race the FIFO.
+type insertTxCache struct {
+	max int
+	m   sync.Map // map[[32]byte]struct{}
+	mu  sync.Mutex
+	q   [][32]byte // FIFO of recent hashes
+}
+
+func newInsertTxCache(max int) *insertTxCache {
+	return &insertTxCache{max: max, q: make([][32]byte, 0, max)}
+}
+
+// Has reports whether the tx-hash was admitted recently.
+func (c *insertTxCache) Has(h [32]byte) bool {
+	_, ok := c.m.Load(h)
+	return ok
+}
+
+// Add records a tx-hash, evicting the oldest entry if at capacity.
+// Safe for concurrent use; duplicates are no-ops.
+func (c *insertTxCache) Add(h [32]byte) {
+	if _, loaded := c.m.LoadOrStore(h, struct{}{}); loaded {
+		return
+	}
+	c.mu.Lock()
+	c.q = append(c.q, h)
+	if len(c.q) > c.max {
+		evict := c.q[0]
+		c.q = c.q[1:]
+		c.m.Delete(evict)
+	}
+	c.mu.Unlock()
 }
 
 // Name returns the name of the BaseApp.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -180,18 +180,18 @@ func NewBaseApp(
 	name string, logger log.Logger, db dbm.DB, txDecoder sdk.TxDecoder, options ...func(*BaseApp),
 ) *BaseApp {
 	app := &BaseApp{
-		logger:               logger.With(log.ModuleKey, "baseapp"),
-		name:                 name,
-		db:                   db,
-		cms:                  store.NewCommitMultiStore(db, logger),
-		storeLoader:          DefaultStoreLoader,
-		grpcQueryRouter:      NewGRPCQueryRouter(),
-		msgServiceRouter:     NewMsgServiceRouter(),
-		txDecoder:            txDecoder,
-		fauxMerkleMode:       false,
-		sigverifyTx:          true,
-		gasConfig:            config.GasConfig{QueryGasLimit: math.MaxUint64},
-		disableBlockGasMeter: true,
+		logger:                logger.With(log.ModuleKey, "baseapp"),
+		name:                  name,
+		db:                    db,
+		cms:                   store.NewCommitMultiStore(db, logger),
+		storeLoader:           DefaultStoreLoader,
+		grpcQueryRouter:       NewGRPCQueryRouter(),
+		msgServiceRouter:      NewMsgServiceRouter(),
+		txDecoder:             txDecoder,
+		fauxMerkleMode:        false,
+		sigverifyTx:           true,
+		gasConfig:             config.GasConfig{QueryGasLimit: math.MaxUint64},
+		disableBlockGasMeter:  true,
 		insertTxCacheSizeHint: -1, // -1 = use default; 0 = disabled; >0 = explicit size
 	}
 

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -374,6 +374,20 @@ func (app *BaseApp) SetInsertTxHandler(handler sdk.InsertTxHandler) {
 	app.abciHandlers.InsertTxHandler = handler
 }
 
+// SetInsertTxSeenCacheSize sets the max number of recent tx-hashes the
+// default InsertTx handler remembers in order to skip AnteHandler runs on
+// gossip-back duplicates under mempool.type=app. Must be called before the
+// BaseApp is sealed.
+//
+// Default: 16384 entries (~512KB at 32-byte sha256). A value <= 0 disables
+// the cache and every InsertTx call runs RunTx(execModeCheck).
+func (app *BaseApp) SetInsertTxSeenCacheSize(n int) {
+	if app.sealed {
+		panic("SetInsertTxSeenCacheSize() on sealed BaseApp")
+	}
+	app.insertTxCacheSizeHint = n
+}
+
 // SetReapTxsHandler sets the ReapTxs function for the BaseApp.
 func (app *BaseApp) SetReapTxsHandler(handler sdk.ReapTxsHandler) {
 	if app.sealed {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -361,6 +361,11 @@ func (app *BaseApp) SetCheckTxHandler(handler sdk.CheckTxHandler) {
 }
 
 // SetInsertTxHandler sets the InsertTx function for the BaseApp.
+//
+// When no handler is set, BaseApp's default InsertTx runs the configured
+// AnteHandler chain via RunTx(execModeCheck, ...). Apps that need full
+// control over admission (custom code mapping, priority stamping, etc.) can
+// override the default by registering a handler here.
 func (app *BaseApp) SetInsertTxHandler(handler sdk.InsertTxHandler) {
 	if app.sealed {
 		panic("SetInsertTxHandler() on sealed BaseApp")


### PR DESCRIPTION
## Summary

Make `BaseApp.InsertTx` run the configured `AnteHandler` by default. Previously it returned `"InsertTx handler not set"` unless an app registered one, so peer-relayed txs under `mempool.type=app` were admitted unverified — bad sigs, wrong chain-id, replayed nonces all reached `FinalizeBlock`.

The default now calls `RunTx(execModeCheck, ...)`, mirroring `CheckTx`. Apps with a custom `InsertTxHandler` keep their override.

## Caveats

- `PriorityNonce` / `SenderNonce` mempools dedup by `(sender, nonce)` via overwrite, not error — RPC + gossip can run `AnteHandler` twice against `checkState`. Same property `CheckTx` already has.
- Nil `AnteHandler` skips validation. Production apps must register one.
