### PR TITLE
fix(baseapp): close multistore opened for historical queries(backport #1808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (baseapp) [#1808](https://github.com/crypto-org-chain/cosmos-sdk/pull/1808) Close multistore opened by `CacheMultiStoreWithVersion` after historical gRPC queries to prevent DB handle leaks.
+
 ### Deprecated
 
 ## [v0.54.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.3) - 2026-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (baseapp) [#1808](https://github.com/crypto-org-chain/cosmos-sdk/pull/1808) Close multistore opened by `CacheMultiStoreWithVersion` after historical gRPC queries to prevent DB handle leaks.
+* (baseapp) [#1816](https://github.com/crypto-org-chain/cosmos-sdk/pull/1816) Close multistore opened for historical queries (backport #1808).
 
 ### Deprecated
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -19,6 +19,7 @@ import (
 
 	coreheader "cosmossdk.io/core/header"
 	errorsmod "cosmossdk.io/errors"
+	log "cosmossdk.io/log/v2"
 
 	"github.com/cosmos/cosmos-sdk/baseapp/state"
 	"github.com/cosmos/cosmos-sdk/baseapp/txnrunner"
@@ -30,6 +31,22 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
+
+// closableMultiStore is optionally implemented by MultiStore backends that need
+// explicit resource cleanup after historical queries (e.g. releasing open DB handles).
+type closableMultiStore interface {
+	Close() error
+}
+
+// closeQueryMultiStore releases resources held by the multistore if it implements
+// closableMultiStore. Any close error is logged rather than silently dropped.
+func closeQueryMultiStore(logger log.Logger, ms storetypes.MultiStore) {
+	if c, ok := ms.(closableMultiStore); ok {
+		if err := c.Close(); err != nil {
+			logger.Error("failed to close query multistore", "err", err)
+		}
+	}
+}
 
 // Supported ABCI Query prefixes and paths
 const (
@@ -1283,6 +1300,10 @@ func (app *BaseApp) handleQueryGRPC(goCtx context.Context, handler GRPCQueryHand
 	if err != nil {
 		return sdkerrors.QueryResult(err, app.trace)
 	}
+
+	defer func() {
+		closeQueryMultiStore(app.logger, ctx.MultiStore())
+	}()
 
 	// add base context for tracing
 	ctx = ctx.WithContext(goCtx)

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -85,6 +85,10 @@ func (app *BaseApp) grpcQueryInterceptor(skipCheckHeader bool) grpc.UnaryServerI
 
 		resp, err = handler(sdkCtx, req)
 
+		defer func() {
+			closeQueryMultiStore(app.logger, sdkCtx.MultiStore())
+		}()
+
 		// If headers were already sent, attach block height as a trailer.
 		if setHeaderErr != nil {
 			if trailerErr := grpc.SetTrailer(grpcCtx, blockHeightMD); trailerErr != nil {

--- a/baseapp/query_close_test.go
+++ b/baseapp/query_close_test.go
@@ -1,0 +1,53 @@
+package baseapp
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log/v2"
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+)
+
+// mockClosableStore satisfies storetypes.MultiStore via embedding and adds Close().
+type mockClosableStore struct {
+	storetypes.MultiStore
+	closeCalled bool
+	closeErr    error
+}
+
+func (m *mockClosableStore) Close() error {
+	m.closeCalled = true
+	return m.closeErr
+}
+
+// mockNonClosableStore satisfies storetypes.MultiStore but has no Close method.
+type mockNonClosableStore struct {
+	storetypes.MultiStore
+}
+
+func TestCloseQueryMultiStore(t *testing.T) {
+	t.Run("calls Close on a closable store", func(t *testing.T) {
+		ms := &mockClosableStore{}
+		closeQueryMultiStore(log.NewNopLogger(), ms)
+		require.True(t, ms.closeCalled)
+	})
+
+	t.Run("no-op for non-closable store", func(t *testing.T) {
+		ms := &mockNonClosableStore{}
+		require.NotPanics(t, func() {
+			closeQueryMultiStore(log.NewNopLogger(), ms)
+		})
+	})
+
+	t.Run("logs error when Close fails", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewLogger(&buf)
+		ms := &mockClosableStore{closeErr: errors.New("disk full")}
+		closeQueryMultiStore(logger, ms)
+		require.True(t, ms.closeCalled)
+		require.Contains(t, buf.String(), "disk full")
+	})
+}

--- a/baseapp/query_close_test.go
+++ b/baseapp/query_close_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cosmossdk.io/log/v2"
+	log "cosmossdk.io/log/v2"
+
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 )
 


### PR DESCRIPTION
## Summary

Backport of [#1808](https://github.com/crypto-org-chain/cosmos-sdk/pull/1808) from `release/v0.53.x` to `release/v0.54.x`.

- `CacheMultiStoreWithVersion` opens DB handles in the gRPC historical query paths (`baseapp/abci.go` and `baseapp/grpcserver.go`) that were never closed, causing file-descriptor leaks under sustained historical query load.
- Adds a `closableMultiStore` interface and a `closeQueryMultiStore` helper that defer-closes the multistore in both paths if the backend implements `Close()`.
- Adds `baseapp/query_close_test.go` to verify the close behaviour.

## Test plan

- [x] `go test ./baseapp/ -run TestCloseQueryMultiStore`
