### PR TITLE
fix(simulation): Disable `SimWriteState` for ethermint compatibility (backport #1760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (simulation) [#1817](https://github.com/crypto-org-chain/cosmos-sdk/pull/1817) Disable `SimWriteState` for ethermint compatibility (backport #1760).
+
 ### Deprecated
 
 ## [v0.54.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.3) - 2026-05-05

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -243,7 +243,9 @@ func SimulateFromSeedX(
 		proposerAddress = validators.randomProposer(r)
 
 		if config.Commit {
-			app.SimWriteState()
+			// this is to be commented out for ethermint simulation tests to pass as this prevents
+			// inconsistent state to be committed during simulation
+			// app.SimWriteState()
 			if _, err := app.Commit(); err != nil {
 				return params, accs, fmt.Errorf("commit failed at height %d: %w", blockHeight, err)
 			}


### PR DESCRIPTION
# Description
Backport of https://github.com/crypto-org-chain/cosmos-sdk/pull/1760 from release/v0.53.x to release/v0.54.x.
Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
