### PR TITLE
fix(baseapp): insert into mempool before committing ante state in CheckTx (backport #26522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (simulation) [#1817](https://github.com/crypto-org-chain/cosmos-sdk/pull/1817) Disable `SimWriteState` for ethermint compatibility (backport #1760).
 * (baseapp) [#1816](https://github.com/crypto-org-chain/cosmos-sdk/pull/1816) Close multistore opened for historical queries (backport #1808).
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
+* (baseapp) [#26521](https://github.com/cosmos/cosmos-sdk/issues/26521) Insert into the mempool before committing the AnteHandler state in `CheckTx`, so a failed `mempool.Insert` (e.g. pool at capacity) no longer advances the sender's nonce in `checkState` for a tx that never entered the pool.
+
+### Deprecated
 
 ## [v0.54.2](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.2) - 2026-04-15
 

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -1599,6 +1599,47 @@ func TestABCI_Proposal_HappyPath(t *testing.T) {
 	require.True(t, res.TxResults[0].IsOK(), fmt.Sprintf("%v", res))
 }
 
+// Verifies a tx that passes the AnteHandler but fails mempool Insert (pool full)
+// does not commit the nonce bump to checkState, which would block resubmission
+// until the next Commit. Ref #26521.
+func TestABCI_CheckTx_MempoolInsertFailure_NoNonceAdvance(t *testing.T) {
+	anteKey := []byte("ante-key")
+	// capacity of 1: the second CheckTx's Insert fails with ErrMempoolTxMaxCapacity.
+	pool := mempool.NewSenderNonceMempool(mempool.SenderNonceMaxTxOpt(1))
+	anteOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetAnteHandler(anteHandlerTxTest(t, capKey1, anteKey))
+	}
+
+	suite := NewBaseAppSuite(t, anteOpt, baseapp.SetMempool(pool))
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), NoopCounterServerImpl{})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{ConsensusParams: &cmtproto.ConsensusParams{}})
+	require.NoError(t, err)
+
+	check := func(counter int64) *abci.ResponseCheckTx {
+		tx := newTxCounter(t, suite.txConfig, counter, counter)
+		txBytes, encErr := suite.txConfig.TxEncoder()(tx)
+		require.NoError(t, encErr)
+		resp, checkErr := suite.baseApp.CheckTx(&abci.RequestCheckTx{Tx: txBytes, Type: abci.CheckTxType_New})
+		require.NoError(t, checkErr)
+		return resp
+	}
+
+	// First tx passes and fills the pool; checkState counter advances to 1.
+	require.True(t, check(0).IsOK())
+	ctx := getCheckStateCtx(suite.baseApp)
+	require.Equal(t, int64(1), getIntFromStore(t, ctx.KVStore(capKey1), anteKey))
+
+	// Second tx passes the ante but Insert fails; counter must stay at 1.
+	resp := check(1)
+	require.False(t, resp.IsOK())
+	require.Contains(t, resp.Log, mempool.ErrMempoolTxMaxCapacity.Error())
+
+	ctx = getCheckStateCtx(suite.baseApp)
+	require.Equal(t, int64(1), getIntFromStore(t, ctx.KVStore(capKey1), anteKey),
+		"failed mempool insert must not advance the sender nonce in checkState")
+}
+
 func TestABCI_Proposal_Read_State_PrepareProposal(t *testing.T) {
 	someKey := []byte("some-key")
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -857,11 +857,13 @@ func (app *BaseApp) RunTx(mode sdk.ExecMode, txBytes []byte, tx sdk.Tx, txIndex 
 		}
 	}
 
+	// AnteHandler state branch. For CheckTx it is committed only after a successful
+	// mempool insert, so a failed insert can't leave the sender's nonce advanced in
+	// checkState for a tx that never entered the pool. Ref #26521.
+	var msCache storetypes.CacheMultiStore
+
 	if app.anteHandler != nil {
-		var (
-			anteCtx sdk.Context
-			msCache storetypes.CacheMultiStore
-		)
+		var anteCtx sdk.Context
 
 		// Branch context before AnteHandler call in case it aborts.
 		// This is required for both CheckTx and DeliverTx.
@@ -910,15 +912,25 @@ func (app *BaseApp) RunTx(mode sdk.ExecMode, txBytes []byte, tx sdk.Tx, txIndex 
 			return gInfo, nil, nil, err
 		}
 
-		msCache.Write()
 		anteEvents = events.ToABCIEvents()
+
+		// CheckTx commits the ante state only after a successful insert.
+		if mode != execModeCheck {
+			msCache.Write()
+		}
 	}
 
 	switch mode {
 	case execModeCheck:
+		// Insert before committing ante state: a failed insert (e.g. mempool full)
+		// must not leave the sender's nonce advanced in checkState. Safe because the
+		// mempool derives the nonce from the tx signature, not the written state.
 		err = app.mempool.Insert(ctx, tx)
 		if err != nil {
 			return gInfo, nil, anteEvents, err
+		}
+		if msCache != nil {
+			msCache.Write()
 		}
 	case execModeFinalize:
 		reason := mempool.RemoveReason{Caller: mempool.CallerRunTxFinalize}


### PR DESCRIPTION
## Description

Backport of cosmos/cosmos-sdk#26522 to `release/v0.54.x`.

### Root Cause

In `BaseApp.runTx`, the AnteHandler's state branch (including the sender's nonce/sequence bump) was committed to `checkState` via `msCache.Write()` **before** `mempool.Insert` was called for `execModeCheck`. If `Insert` then failed (e.g. `ErrMempoolTxMaxCapacity` when the pool is full), `runTx` returned the error with the nonce **already advanced** in `checkState` for a tx that never entered the pool. The sender's next `CheckTx` of that nonce was then rejected by the AnteHandler with "incorrect account sequence" until the next `Commit`.

### Fix

For `execModeCheck`, insert into the mempool **before** committing the ante state. A failed insert now leaves `checkState` untouched. All other modes commit the ante state immediately, as before.

The standard mempools (`PriorityNonceMempool`, `SenderNonceMempool`) derive the nonce from the tx signature, not the written multistore, so the reorder is state-correctness-safe.

## Changes

- `baseapp/baseapp.go`: reorder mempool insert before `msCache.Write()` for `execModeCheck`
- `baseapp/abci_test.go`: add `TestABCI_CheckTx_MempoolInsertFailure_NoNonceAdvance`

## Adaptation Notes

- Adapted `mempool.Insert` call to `v0.54.x` signature (no `InsertOption` parameter)