### PR TITLE
 fix(blockstm): count validation tasks before advancing validationIdx to prevent lost updates

### DIFF
--- a/internal/blockstm/scheduler.go
+++ b/internal/blockstm/scheduler.go
@@ -114,12 +114,16 @@ func (s *Scheduler) NextVersionToExecute() TxnVersion {
 // TryValidateNextVersion get the next transaction index to validate,
 // returns invalid version if no task is available.
 func (s *Scheduler) TryValidateNextVersion(idxToValidate uint64) (TxnVersion, bool) {
+	IncrAtomic(&s.numActiveTasks)
+
 	if !s.validationIdx.CompareAndSwap(idxToValidate, idxToValidate+1) {
+		DecrAtomic(&s.numActiveTasks)
 		return InvalidTxnVersion, false
 	}
 
 	incarnation, ok := s.txnStatus[idxToValidate].IsExecuted()
 	if !ok {
+		DecrAtomic(&s.numActiveTasks)
 		return InvalidTxnVersion, false
 	}
 
@@ -139,7 +143,6 @@ func (s *Scheduler) NextTask() (TxnVersion, TaskKind) {
 
 	if preferValidate {
 		if version, ok := s.TryValidateNextVersion(validationIdx); ok {
-			IncrAtomic(&s.numActiveTasks)
 			return version, TaskKindValidation
 		}
 	}

--- a/internal/blockstm/scheduler_lostupdate_test.go
+++ b/internal/blockstm/scheduler_lostupdate_test.go
@@ -1,0 +1,60 @@
+package blockstm
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+)
+
+// counterOnlyBlock is the minimal maximum-contention block: every transaction
+// does a read-modify-write on a single hot key. A correct serial (and any
+// serializable parallel) execution of N such transactions must leave the
+// counter at exactly N.
+func counterOnlyBlock(size int) *MockBlock {
+	txs := make([]Tx, size)
+	for i := range size {
+		txs[i] = func(ms MultiStore, _ Cache) error {
+			acc := ms.GetKVStore(StoreKeyAuth)
+			ctr := []byte("counter")
+			var n uint64
+			if v := acc.Get(ctr); v != nil {
+				n = binary.BigEndian.Uint64(v)
+			}
+			n++
+			var bz [8]byte
+			binary.BigEndian.PutUint64(bz[:], n)
+			acc.Set(ctr, bz[:])
+			return nil
+		}
+	}
+	return NewMockBlock(txs)
+}
+
+// TestSchedulerNoLostUpdates is a regression test for a scheduler bug where the
+// validation task path incremented numActiveTasks AFTER advancing validationIdx,
+// opening a window in which CheckDone could latch doneMarker=true while a
+// validation (that would abort a stale-read txn and reschedule work) was still
+// pending. The dropped re-executions committed stale reads => lost updates.
+//
+// The bug is a rare interleaving; it reproduces most reliably under `-race`,
+// which perturbs goroutine scheduling. Before the fix, the counter dropped
+// below blockSize within a few hundred iterations.
+func TestSchedulerNoLostUpdates(t *testing.T) {
+	stores := map[storetypes.StoreKey]int{StoreKeyAuth: 0, StoreKeyBank: 1}
+	const blockSize = 80
+	for iter := range 1500 {
+		blk := counterOnlyBlock(blockSize)
+		storage := NewMultiMemDB(stores)
+		require.NoError(t, ExecuteBlock(context.Background(), blk.Size(), stores, storage, 8,
+			func(txn TxnIndex, store MultiStore) { blk.ExecuteTx(txn, store, nil) }))
+
+		got := binary.BigEndian.Uint64(storage.GetKVStore(StoreKeyAuth).Get([]byte("counter")))
+		require.Equalf(t, uint64(blockSize), got,
+			"iter %d: counter=%d, want %d (lost %d committed updates)",
+			iter, got, blockSize, blockSize-int(got))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a critical correctness bug in the Block-STM scheduler where a block could be
marked "done" while a validation task was still in flight, causing rescheduled
re-executions to be dropped and **stale reads to be committed** — i.e. the parallel
execution result was not serially equivalent (lost updates).

## Root cause

Block-STM's termination check (`CheckDone`) relies on the invariant that an in-flight
task is reflected in `numActiveTasks` *before* it becomes invisible in the progress
indices. The execution path honors this (`IncrAtomic` before `executionIdx.Add`), but
the **validation path did the opposite**: `TryValidateNextVersion` advanced
`validationIdx` via `CompareAndSwap`, and `numActiveTasks` was only incremented
afterward in `NextTask`.

Between those two steps there is a window where `validationIdx >= blockSize` while
`numActiveTasks == 0`. A concurrent idle executor in `CheckDone` observes
`executionIdx>=blockSize && validationIdx>=blockSize && numActiveTasks==0` with a stable
`decreaseCnt` and latches `doneMarker = true`. When the pending validation then aborts a
stale-read transaction and calls `DecreaseValidationIdx` to reschedule work, that work is
ignored — `doneMarker` is a one-way latch — so executors exit and the stale incarnation
stays committed.

## Fix

Increment `numActiveTasks` **before** advancing `validationIdx`, and decrement on the
early-return branches — matching the correct execution path, the Block-STM paper
(Algorithm 4), and upstream `go-block-stm`'s `NextVersionToValidate`. After the fix,
`numActiveTasks > 0` holds for the entire lifetime of a validation task, so `CheckDone`
can never observe a false "0 active" state.