### PR TITLE
fix(distribution): add strict + fallback behavior when withdrawing delegator rewards (backport #26406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (simulation) [#1817](https://github.com/crypto-org-chain/cosmos-sdk/pull/1817) Disable `SimWriteState` for ethermint compatibility (backport #1760).
 * (baseapp) [#1816](https://github.com/crypto-org-chain/cosmos-sdk/pull/1816) Close multistore opened for historical queries (backport #1808).
+* (x/distribution) [#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) Add fallback paths (delegator/validator owner, then community pool) when withdrawing delegator rewards or validator commission to a blocked address during `Begin/EndBlockers`. user msg initiated paths still return `ErrUnauthorized` when withdrawing to blocked addresses.
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 
 ## [v0.54.2](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.2) - 2026-04-15

--- a/x/distribution/README.md
+++ b/x/distribution/README.md
@@ -61,6 +61,21 @@ you are incentivized to not withdraw until after this event, increasing the
 worth of your existing _accum_. See [#2764](https://github.com/cosmos/cosmos-sdk/issues/2764)
 for further details.
 
+### Bank send restrictions and when called from Begin/EndBlocker hooks
+
+x/distribution sends rewards and commission via
+`bankKeeper.SendCoinsFromModuleToAccount`, which runs any registered
+`SendRestrictionFunc`. The resolver added in
+[#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) handles addresses in
+the bank module's blocked set by falling back (delegator → community pool for
+rewards, validator owner → community pool for commission), but it cannot
+intercept custom `SendRestrictionFunc` rejections. If a chain registers a
+restriction that can error on transfers from the distribution module account to
+a delegator or validator, that error will surface during the reward-withdrawal
+hooks fired from BeginBlocker / EndBlocker / validator-removal paths and cause
+large problems. Restrictions wired onto these flows must be unconditionally
+non-failing for the distribution module's outflows.
+
 ## Effect on Staking
 
 Charging commission on Atom provisions while also allowing for Atom-provisions

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -1,12 +1,15 @@
 package keeper
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -191,7 +194,135 @@ func (k Keeper) CalculateDelegationRewards(ctx context.Context, val stakingtypes
 	return rewards, nil
 }
 
-func (k Keeper) withdrawDelegationRewards(ctx context.Context, val stakingtypes.ValidatorI, del stakingtypes.DelegationI) (sdk.Coins, error) {
+// withdrawDestination is the resolved target for a reward withdrawal.
+// String yields the value used for the withdraw_address event attribute.
+type withdrawDestination interface {
+	IsRedirected() bool
+	SpecifiedWithdrawAddress() string
+	ResolvedWithdrawAddress() string
+}
+
+// withdrawToAddr routes rewards to a specific account via the bank module.
+type withdrawToAddr struct {
+	ResolvedWithdrawAddr  sdk.AccAddress
+	SpecifiedWithdrawAddr sdk.AccAddress
+}
+
+func newWithdrawToAddress(resolved, specified sdk.AccAddress) withdrawToAddr {
+	return withdrawToAddr{
+		ResolvedWithdrawAddr:  resolved,
+		SpecifiedWithdrawAddr: specified,
+	}
+}
+
+func (d withdrawToAddr) IsRedirected() bool {
+	return !bytes.Equal(d.ResolvedWithdrawAddr, d.SpecifiedWithdrawAddr)
+}
+
+func (d withdrawToAddr) SpecifiedWithdrawAddress() string {
+	return d.SpecifiedWithdrawAddr.String()
+}
+
+func (d withdrawToAddr) ResolvedWithdrawAddress() string {
+	return d.ResolvedWithdrawAddr.String()
+}
+
+// withdrawToCommunityPool credits rewards to the community pool.
+type withdrawToCommunityPool struct {
+	SpecifiedWithdrawAddr sdk.AccAddress
+}
+
+func newWithdrawToCommunityPool(specified sdk.AccAddress) withdrawToCommunityPool {
+	return withdrawToCommunityPool{SpecifiedWithdrawAddr: specified}
+}
+
+func (withdrawToCommunityPool) IsRedirected() bool {
+	return true
+}
+
+func (d withdrawToCommunityPool) SpecifiedWithdrawAddress() string {
+	return d.SpecifiedWithdrawAddr.String()
+}
+
+func (withdrawToCommunityPool) ResolvedWithdrawAddress() string {
+	return types.AttributeValueCommunityPool
+}
+
+// resolveWithdrawDestination resolves a withdraw destination based on if the
+// withdraw is 'strict' or not. a withdraw being strict or not determines if
+// fallback addresses should be used or not. if a withdraw is strict, the
+// withdraw must go to the owners specified withdraw address, and if it cannot
+// for some reason, an error is returned. if a withdraw is not strict and it
+// cannot go to the owner's specified withdraw address, it will fallback to the
+// owner's address itself. if the owner's address cannot be used, it will
+// fallback to the community pool.
+func (k Keeper) resolveWithdrawDestination(
+	ctx context.Context,
+	owner sdk.AccAddress,
+	strict bool,
+) (withdrawDestination, error) {
+	if strict {
+		return k.resolveWithdrawDestinationStrict(ctx, owner)
+	}
+	return k.resolveWithdrawDestinationFallback(ctx, owner)
+}
+
+// resolveWithdrawDestinationStrict returns the destination for owner's stored
+// withdraw address. If that address is in the bank module's blocked set, it
+// returns ErrWithdrawAddrBlocked.
+func (k Keeper) resolveWithdrawDestinationStrict(
+	ctx context.Context,
+	owner sdk.AccAddress,
+) (withdrawToAddr, error) {
+	withdrawAddr, err := k.GetDelegatorWithdrawAddr(ctx, owner)
+	if err != nil {
+		return withdrawToAddr{}, err
+	}
+	if k.bankKeeper.BlockedAddr(withdrawAddr) {
+		// copying error return that the bank module uses when it tries to send
+		// to a blocked address
+		return withdrawToAddr{}, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", withdrawAddr)
+	}
+	return newWithdrawToAddress(withdrawAddr, withdrawAddr), nil
+}
+
+// resolveWithdrawDestinationFallback returns the destination for owner's
+// stored withdraw address. If that address is in the bank module's blocked
+// set, it falls back to the owner's address itself. If the owner's address is
+// in the bank module's blocked set, it falls back to the community pool.
+func (k Keeper) resolveWithdrawDestinationFallback(
+	ctx context.Context,
+	owner sdk.AccAddress,
+) (withdrawDestination, error) {
+	withdrawAddr, err := k.GetDelegatorWithdrawAddr(ctx, owner)
+	if err != nil {
+		return nil, err
+	}
+
+	if !k.bankKeeper.BlockedAddr(withdrawAddr) {
+		return newWithdrawToAddress(withdrawAddr, withdrawAddr), nil
+	}
+	if !k.bankKeeper.BlockedAddr(owner) {
+		return newWithdrawToAddress(owner, withdrawAddr), nil
+	}
+	return newWithdrawToCommunityPool(withdrawAddr), nil
+}
+
+func emitWithdrawDestinationRedirectedEvent(ctx context.Context, dest withdrawDestination, validatorOp, delegatorAddr string) {
+	attrs := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyOriginalWithdrawAddress, dest.SpecifiedWithdrawAddress()),
+		sdk.NewAttribute(types.AttributeKeyWithdrawAddress, dest.ResolvedWithdrawAddress()),
+		sdk.NewAttribute(types.AttributeKeyValidator, validatorOp),
+	}
+	if delegatorAddr != "" {
+		attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyDelegator, delegatorAddr))
+	}
+	sdk.UnwrapSDKContext(ctx).EventManager().EmitEvent(sdk.NewEvent(types.EventTypeWithdrawAddrRedirected, attrs...))
+}
+
+// withdrawDelegationRewards withdrawals rewards to a given withdraw
+// destination.
+func (k Keeper) withdrawDelegationRewards(ctx context.Context, val stakingtypes.ValidatorI, del stakingtypes.DelegationI, dest withdrawDestination) (sdk.Coins, error) {
 	addrCodec := k.authKeeper.AddressCodec()
 	delAddr, err := addrCodec.StringToBytes(del.GetDelegatorAddr())
 	if err != nil {
@@ -243,36 +374,12 @@ func (k Keeper) withdrawDelegationRewards(ctx context.Context, val stakingtypes.
 		)
 	}
 
-	// truncate reward dec coins, return remainder to community pool
-	finalRewards, remainder := rewards.TruncateDecimal()
-
-	// add coins to user account
-	if !finalRewards.IsZero() {
-		withdrawAddr, err := k.GetDelegatorWithdrawAddr(ctx, delAddr)
-		if err != nil {
-			return nil, err
-		}
-
-		err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, withdrawAddr, finalRewards)
-		if err != nil {
-			return nil, err
-		}
+	finalRewards, err := k.sendCoinsToDestination(ctx, rewards, dest)
+	if err != nil {
+		return nil, err
 	}
 
-	// update the outstanding rewards and the community pool only if the
-	// transaction was successful
 	err = k.SetValidatorOutstandingRewards(ctx, sdk.ValAddress(valAddr), types.ValidatorOutstandingRewards{Rewards: outstanding.Sub(rewards)})
-	if err != nil {
-		return nil, err
-	}
-
-	feePool, err := k.FeePool.Get(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	feePool.CommunityPool = feePool.CommunityPool.Add(remainder...)
-	err = k.FeePool.Set(ctx, feePool)
 	if err != nil {
 		return nil, err
 	}
@@ -306,8 +413,7 @@ func (k Keeper) withdrawDelegationRewards(ctx context.Context, val stakingtypes.
 		finalRewards = sdk.Coins{sdk.NewCoin(baseDenom, math.ZeroInt())}
 	}
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
+	sdk.UnwrapSDKContext(ctx).EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeWithdrawRewards,
 			sdk.NewAttribute(sdk.AttributeKeyAmount, finalRewards.String()),
@@ -317,4 +423,38 @@ func (k Keeper) withdrawDelegationRewards(ctx context.Context, val stakingtypes.
 	)
 
 	return finalRewards, nil
+}
+
+// sendCoinsToDestination sends the truncated coins to dest and routes the
+// decimal remainder (and the truncated coins themselves, for the community-pool
+// destination) into FeePool.CommunityPool.
+func (k Keeper) sendCoinsToDestination(ctx context.Context, coins sdk.DecCoins, dest withdrawDestination) (sdk.Coins, error) {
+	toSend, remainder := coins.TruncateDecimal()
+
+	communityPoolFunds := remainder
+	switch d := dest.(type) {
+	case withdrawToAddr:
+		if !toSend.IsZero() {
+			if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, d.ResolvedWithdrawAddr, toSend); err != nil {
+				return nil, err
+			}
+		}
+	case withdrawToCommunityPool:
+		communityPoolFunds = communityPoolFunds.Add(sdk.NewDecCoinsFromCoins(toSend...)...)
+	default:
+		return nil, fmt.Errorf("unknown withdraw destination type %T", dest)
+	}
+
+	if !communityPoolFunds.IsZero() {
+		feePool, err := k.FeePool.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		feePool.CommunityPool = feePool.CommunityPool.Add(communityPoolFunds...)
+		if err := k.FeePool.Set(ctx, feePool); err != nil {
+			return nil, err
+		}
+	}
+
+	return toSend, nil
 }

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -38,6 +38,7 @@ func TestCalculateRewardsBasic(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -123,6 +124,7 @@ func TestCalculateRewardsAfterSlash(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -226,6 +228,7 @@ func TestCalculateRewardsAfterManySlashes(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -350,6 +353,7 @@ func TestCalculateRewardsMultiDelegator(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -447,6 +451,7 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -522,6 +527,7 @@ func TestCalculateRewardsAfterManySlashesInSameBlock(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -638,6 +644,7 @@ func TestCalculateRewardsMultiDelegatorMultiSlash(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -775,6 +782,7 @@ func TestCalculateRewardsMultiDelegatorMultiWithdraw(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,
@@ -974,6 +982,7 @@ func Test100PercentCommissionReward(t *testing.T) {
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	distrKeeper := keeper.NewKeeper(
 		encCfg.Codec,

--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -6,7 +6,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -50,32 +49,29 @@ func (h Hooks) AfterValidatorRemoved(ctx context.Context, _ sdk.ConsAddress, val
 		// subtract from outstanding
 		outstanding = outstanding.Sub(commission)
 
-		// split into integral & remainder
-		coins, remainder := commission.TruncateDecimal()
-
-		// remainder to community pool
-		feePool, err := h.k.FeePool.Get(ctx)
+		// cant lookup validator from state since it has been removed
+		valOperator, err := h.k.stakingKeeper.ValidatorAddressCodec().BytesToString(valAddr)
 		if err != nil {
 			return err
 		}
 
-		feePool.CommunityPool = feePool.CommunityPool.Add(remainder...)
-		err = h.k.FeePool.Set(ctx, feePool)
+		// check if staking module is telling us we should use a strict
+		// withdraw or not
+		strict := stakingtypes.IsStrictWithdraw(ctx)
+
+		// determine where commission for this validator should go based on
+		// strict flag
+		dest, err := h.k.resolveWithdrawDestination(ctx, sdk.AccAddress(valAddr), strict)
 		if err != nil {
 			return err
 		}
+		if _, err := h.k.sendCoinsToDestination(ctx, commission, dest); err != nil {
+			return err
+		}
 
-		// add to validator account
-		if !coins.IsZero() {
-			accAddr := sdk.AccAddress(valAddr)
-			withdrawAddr, err := h.k.GetDelegatorWithdrawAddr(ctx, accAddr)
-			if err != nil {
-				return err
-			}
-
-			if err := h.k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, withdrawAddr, coins); err != nil {
-				return err
-			}
+		// if we have modified the withdraw destination, emit an event saying so
+		if dest.IsRedirected() {
+			emitWithdrawDestinationRedirectedEvent(ctx, dest, valOperator, "")
 		}
 	}
 
@@ -143,8 +139,24 @@ func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.A
 		return err
 	}
 
-	if _, err := h.k.withdrawDelegationRewards(ctx, val, del); err != nil {
+	// check if staking module is telling us we should use a strict
+	// withdraw or not
+	strict := stakingtypes.IsStrictWithdraw(ctx)
+
+	// determine where rewards for this delegator should go based on
+	// strict flag
+	dest, err := h.k.resolveWithdrawDestination(ctx, delAddr, strict)
+	if err != nil {
 		return err
+	}
+
+	if _, err := h.k.withdrawDelegationRewards(ctx, val, del, dest); err != nil {
+		return err
+	}
+
+	// if we have modified the withdraw destination, emit an event saying so
+	if dest.IsRedirected() {
+		emitWithdrawDestinationRedirectedEvent(ctx, dest, val.GetOperator(), del.GetDelegatorAddr())
 	}
 
 	return nil

--- a/x/distribution/keeper/hooks_test.go
+++ b/x/distribution/keeper/hooks_test.go
@@ -1,0 +1,369 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"cosmossdk.io/math"
+
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	"github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtestutil "github.com/cosmos/cosmos-sdk/x/distribution/testutil"
+	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// TestBeforeDelegationSharesModified exercises the three reward-withdrawal
+// paths the hook can take: fallback to the delegator account, fallback to the
+// community pool when the delegator is also blocked, and the strict path
+// where a blocked withdraw addr surfaces ErrUnauthorized.
+func TestBeforeDelegationSharesModified(t *testing.T) {
+	valAddr := sdk.ValAddress(valConsAddr0)
+	withdrawAddr := sdk.AccAddress(valConsAddr1)
+	owner := sdk.AccAddress(valAddr)
+
+	tests := []struct {
+		name string
+
+		strict              bool
+		withdrawAddrBlocked bool
+		ownerBlocked        bool
+
+		expectedError           error
+		expectedWithdrawAddress string
+	}{
+		{
+			name:                    "fallback path, withdraw addr not blocked",
+			strict:                  false,
+			withdrawAddrBlocked:     false,
+			ownerBlocked:            false,
+			expectedError:           nil,
+			expectedWithdrawAddress: withdrawAddr.String(),
+		},
+		{
+			name:                    "fallback path, withdraw addr blocked, delegator not blocked, redirects to delegator",
+			strict:                  false,
+			withdrawAddrBlocked:     true,
+			ownerBlocked:            false,
+			expectedError:           nil,
+			expectedWithdrawAddress: owner.String(),
+		},
+		{
+			name:                    "fallback path, withdraw addr blocked, delegator also blocked, redirects to community pool",
+			strict:                  false,
+			withdrawAddrBlocked:     true,
+			ownerBlocked:            true,
+			expectedError:           nil,
+			expectedWithdrawAddress: disttypes.AttributeValueCommunityPool,
+		},
+		{
+			name:                    "strict path, withdraw addr blocked, ErrUnauthorized",
+			strict:                  true,
+			withdrawAddrBlocked:     true,
+			ownerBlocked:            false, // unread on strict path: resolver errors out before checking fallback
+			expectedError:           sdkerrors.ErrUnauthorized,
+			expectedWithdrawAddress: "",
+		},
+		{
+			name:                    "strict path, withdraw addr not blocked",
+			strict:                  true,
+			withdrawAddrBlocked:     false,
+			ownerBlocked:            false,
+			expectedError:           nil,
+			expectedWithdrawAddress: withdrawAddr.String(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			key := storetypes.NewKVStoreKey(disttypes.StoreKey)
+			storeService := runtime.NewKVStoreService(key)
+			testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+			encCfg := moduletestutil.MakeTestEncodingConfig(distribution.AppModuleBasic{})
+			ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Height: 1})
+
+			bankKeeper := distrtestutil.NewMockBankKeeper(ctrl)
+			stakingKeeper := distrtestutil.NewMockStakingKeeper(ctrl)
+			accountKeeper := distrtestutil.NewMockAccountKeeper(ctrl)
+
+			accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
+			stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
+			accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+
+			distrKeeper := keeper.NewKeeper(
+				encCfg.Codec, storeService, accountKeeper, bankKeeper, stakingKeeper,
+				"fee_collector", authtypes.NewModuleAddress("gov").String(),
+			)
+
+			require.NoError(t, distrKeeper.FeePool.Set(ctx, disttypes.InitialFeePool()))
+			require.NoError(t, distrKeeper.Params.Set(ctx, disttypes.DefaultParams()))
+
+			val, err := distrtestutil.CreateValidator(valConsPk0, math.NewInt(100))
+			require.NoError(t, err)
+			val.Commission = stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyNewDecWithPrec(5, 1), math.LegacyNewDec(0))
+
+			del := stakingtypes.NewDelegation(owner.String(), valAddr.String(), val.DelegatorShares)
+			stakingKeeper.EXPECT().Validator(gomock.Any(), valAddr).Return(val, nil).AnyTimes()
+			stakingKeeper.EXPECT().Delegation(gomock.Any(), owner, valAddr).Return(del, nil).AnyTimes()
+
+			require.NoError(t, distrtestutil.CallCreateValidatorHooks(ctx, distrKeeper, owner, valAddr))
+			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+			require.NoError(t, distrKeeper.SetDelegatorWithdrawAddr(ctx, owner, withdrawAddr))
+
+			initial := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+			require.NoError(t, distrKeeper.AllocateTokensToValidator(ctx, val, sdk.DecCoins{sdk.NewDecCoin(sdk.DefaultBondDenom, initial)}))
+
+			expRewards := sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, initial)}
+
+			bankKeeper.EXPECT().BlockedAddr(withdrawAddr).Return(tc.withdrawAddrBlocked).Times(1)
+			switch {
+			case !tc.withdrawAddrBlocked:
+				// happy path: hook sends rewards directly to configured withdraw addr
+				bankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), disttypes.ModuleName, withdrawAddr, expRewards).Return(nil).Times(1)
+			case !tc.strict:
+				// fallback path: check the owner addr next
+				bankKeeper.EXPECT().BlockedAddr(owner).Return(tc.ownerBlocked).Times(1)
+				if !tc.ownerBlocked {
+					bankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), disttypes.ModuleName, owner, expRewards).Return(nil).Times(1)
+				}
+				// else: rewards go to community pool, no bank Send
+			}
+			// strict + withdrawAddrBlocked: resolver errors immediately, no further bank calls
+
+			var cpBefore disttypes.FeePool
+			if tc.expectedWithdrawAddress == disttypes.AttributeValueCommunityPool {
+				cpBefore, err = distrKeeper.FeePool.Get(ctx)
+				require.NoError(t, err)
+			}
+
+			eventCtx := ctx.WithEventManager(sdk.NewEventManager())
+			var hookCtx context.Context = eventCtx
+			if tc.strict {
+				hookCtx = stakingtypes.WithStrictWithdraw(eventCtx)
+			}
+
+			err = distrKeeper.Hooks().BeforeDelegationSharesModified(hookCtx, owner, valAddr)
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+
+			// assert there was a redirect event if we did not send funds to the set withdraw address
+			if tc.expectedWithdrawAddress != withdrawAddr.String() {
+				requireRedirectEvent(t, eventCtx.EventManager(), withdrawAddr.String(), tc.expectedWithdrawAddress)
+			}
+
+			// pool-fallback path: pool absorbs the full truncated reward, and
+			// outstanding rewards drain to zero.
+			if tc.expectedWithdrawAddress == disttypes.AttributeValueCommunityPool {
+				cpAfter, err := distrKeeper.FeePool.Get(ctx)
+				require.NoError(t, err)
+				diff := cpAfter.CommunityPool.Sub(cpBefore.CommunityPool)
+				require.True(t,
+					diff.AmountOf(sdk.DefaultBondDenom).Equal(math.LegacyNewDecFromInt(expRewards[0].Amount)),
+					"community pool delta should equal the truncated reward amount; got %s want %s",
+					diff, expRewards[0].Amount,
+				)
+				outstanding, err := distrKeeper.GetValidatorOutstandingRewardsCoins(ctx, valAddr)
+				require.NoError(t, err)
+				require.True(t, outstanding.IsZero(), "expected outstanding rewards to be fully drained, got %s", outstanding)
+			}
+		})
+	}
+}
+
+func TestAfterValidatorRemoved(t *testing.T) {
+	valAddr := sdk.ValAddress(valConsAddr0)
+	withdrawAddr := sdk.AccAddress(valConsAddr1)
+	owner := sdk.AccAddress(valAddr)
+
+	tests := []struct {
+		name string
+
+		strict              bool
+		withdrawAddrBlocked bool
+		ownerBlocked        bool // only consulted on the fallback path when withdrawAddrBlocked
+
+		expectedError           error
+		expectedWithdrawAddress string
+	}{
+		{
+			name:                    "fallback path, withdraw addr not blocked",
+			strict:                  false,
+			withdrawAddrBlocked:     false,
+			ownerBlocked:            false,
+			expectedError:           nil,
+			expectedWithdrawAddress: withdrawAddr.String(),
+		},
+		{
+			name:                    "fallback path, withdraw addr blocked, owner not blocked, redirects to validator owner",
+			strict:                  false,
+			withdrawAddrBlocked:     true,
+			ownerBlocked:            false,
+			expectedError:           nil,
+			expectedWithdrawAddress: owner.String(),
+		},
+		{
+			name:                    "fallback path, withdraw addr blocked, owner also blocked, redirects to community pool",
+			strict:                  false,
+			withdrawAddrBlocked:     true,
+			ownerBlocked:            true,
+			expectedError:           nil,
+			expectedWithdrawAddress: disttypes.AttributeValueCommunityPool,
+		},
+		{
+			name:                    "strict path, withdraw addr not blocked",
+			strict:                  true,
+			withdrawAddrBlocked:     false,
+			ownerBlocked:            false,
+			expectedError:           nil,
+			expectedWithdrawAddress: withdrawAddr.String(),
+		},
+		{
+			name:                    "strict path, withdraw addr blocked, ErrUnauthorized",
+			strict:                  true,
+			withdrawAddrBlocked:     true,
+			ownerBlocked:            false, // unread on strict path: resolver errors out before checking fallback
+			expectedError:           sdkerrors.ErrUnauthorized,
+			expectedWithdrawAddress: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			key := storetypes.NewKVStoreKey(disttypes.StoreKey)
+			storeService := runtime.NewKVStoreService(key)
+			testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+			encCfg := moduletestutil.MakeTestEncodingConfig(distribution.AppModuleBasic{})
+			ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Height: 1})
+
+			bankKeeper := distrtestutil.NewMockBankKeeper(ctrl)
+			stakingKeeper := distrtestutil.NewMockStakingKeeper(ctrl)
+			accountKeeper := distrtestutil.NewMockAccountKeeper(ctrl)
+
+			accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
+			stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
+			accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+
+			distrKeeper := keeper.NewKeeper(
+				encCfg.Codec, storeService, accountKeeper, bankKeeper, stakingKeeper,
+				"fee_collector", authtypes.NewModuleAddress("gov").String(),
+			)
+
+			require.NoError(t, distrKeeper.FeePool.Set(ctx, disttypes.InitialFeePool()))
+			require.NoError(t, distrKeeper.Params.Set(ctx, disttypes.DefaultParams()))
+
+			val, err := distrtestutil.CreateValidator(valConsPk0, math.NewInt(100))
+			require.NoError(t, err)
+			// 50% commission rate so commission accrues
+			val.Commission = stakingtypes.NewCommission(math.LegacyNewDecWithPrec(5, 1), math.LegacyNewDecWithPrec(5, 1), math.LegacyNewDec(0))
+
+			del := stakingtypes.NewDelegation(owner.String(), valAddr.String(), val.DelegatorShares)
+			stakingKeeper.EXPECT().Validator(gomock.Any(), valAddr).Return(val, nil).AnyTimes()
+			stakingKeeper.EXPECT().Delegation(gomock.Any(), owner, valAddr).Return(del, nil).AnyTimes()
+
+			require.NoError(t, distrtestutil.CallCreateValidatorHooks(ctx, distrKeeper, owner, valAddr))
+			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+			require.NoError(t, distrKeeper.SetDelegatorWithdrawAddr(ctx, owner, withdrawAddr))
+
+			initial := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+			require.NoError(t, distrKeeper.AllocateTokensToValidator(ctx, val, sdk.DecCoins{sdk.NewDecCoin(sdk.DefaultBondDenom, initial)}))
+
+			expCommission := sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, initial.Quo(math.NewInt(2)))}
+
+			bankKeeper.EXPECT().BlockedAddr(withdrawAddr).Return(tc.withdrawAddrBlocked).Times(1)
+			switch {
+			case !tc.withdrawAddrBlocked:
+				// happy path: hook sends commission directly to configured withdraw addr
+				bankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), disttypes.ModuleName, withdrawAddr, expCommission).Return(nil).Times(1)
+			case !tc.strict:
+				// fallback path: check the validator owner addr next
+				bankKeeper.EXPECT().BlockedAddr(owner).Return(tc.ownerBlocked).Times(1)
+				if !tc.ownerBlocked {
+					bankKeeper.EXPECT().SendCoinsFromModuleToAccount(gomock.Any(), disttypes.ModuleName, owner, expCommission).Return(nil).Times(1)
+				}
+				// else: commission goes to community pool, no bank Send
+			}
+			// strict + withdrawAddrBlocked: resolver errors immediately, no further bank calls
+
+			var cpBefore disttypes.FeePool
+			if tc.expectedWithdrawAddress == disttypes.AttributeValueCommunityPool {
+				cpBefore, err = distrKeeper.FeePool.Get(ctx)
+				require.NoError(t, err)
+			}
+
+			eventCtx := ctx.WithEventManager(sdk.NewEventManager())
+			var hookCtx context.Context = eventCtx
+			if tc.strict {
+				hookCtx = stakingtypes.WithStrictWithdraw(eventCtx)
+			}
+
+			err = distrKeeper.Hooks().AfterValidatorRemoved(hookCtx, valConsAddr0, valAddr)
+			if tc.expectedError != nil {
+				// partial keeper-level state mutation isn't asserted; staking
+				// already swallows hook errors, and any tx-level rollback
+				// covers the user-msg path.
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+
+			// assert there was a redirect event if we did not send funds to the set withdraw address
+			if tc.expectedWithdrawAddress != withdrawAddr.String() {
+				requireRedirectEvent(t, eventCtx.EventManager(), withdrawAddr.String(), tc.expectedWithdrawAddress)
+			}
+
+			// pool-fallback path: pool absorbs the full allocation (commission
+			// redirected to pool plus the leftover dust outstanding).
+			if tc.expectedWithdrawAddress == disttypes.AttributeValueCommunityPool {
+				cpAfter, err := distrKeeper.FeePool.Get(ctx)
+				require.NoError(t, err)
+				diff := cpAfter.CommunityPool.Sub(cpBefore.CommunityPool)
+				require.True(t,
+					diff.AmountOf(sdk.DefaultBondDenom).Equal(math.LegacyNewDecFromInt(initial)),
+					"community pool delta should equal the full allocation; got %s want %s",
+					diff, initial,
+				)
+			}
+		})
+	}
+}
+
+func requireRedirectEvent(t *testing.T, em *sdk.EventManager, original, final string) {
+	t.Helper()
+	for _, ev := range em.Events() {
+		if ev.Type != disttypes.EventTypeWithdrawAddrRedirected {
+			continue
+		}
+		var foundOriginal, foundFinal bool
+		for _, attr := range ev.Attributes {
+			if attr.Key == disttypes.AttributeKeyOriginalWithdrawAddress && attr.Value == original {
+				foundOriginal = true
+			}
+			if attr.Key == disttypes.AttributeKeyWithdrawAddress && attr.Value == final {
+				foundFinal = true
+			}
+		}
+		if foundOriginal && foundFinal {
+			return
+		}
+	}
+	t.Fatalf("expected withdraw_addr_redirected event with original %q and final %q", original, final)
+}

--- a/x/distribution/keeper/keeper.go
+++ b/x/distribution/keeper/keeper.go
@@ -163,8 +163,13 @@ func (k Keeper) WithdrawDelegationRewards(ctx context.Context, delAddr sdk.AccAd
 		return nil, types.ErrEmptyDelegationDistInfo
 	}
 
-	// withdraw rewards
-	rewards, err := k.withdrawDelegationRewards(ctx, val, del)
+	// determine where rewards for this delegator should go
+	dest, err := k.resolveWithdrawDestinationStrict(ctx, delAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	rewards, err := k.withdrawDelegationRewards(ctx, val, del, dest)
 	if err != nil {
 		return nil, err
 	}
@@ -207,13 +212,13 @@ func (k Keeper) WithdrawValidatorCommission(ctx context.Context, valAddr sdk.Val
 	}
 
 	if !commission.IsZero() {
-		accAddr := sdk.AccAddress(valAddr)
-		withdrawAddr, err := k.GetDelegatorWithdrawAddr(ctx, accAddr)
+		// determine where commission for this validator should go
+		dest, err := k.resolveWithdrawDestinationStrict(ctx, sdk.AccAddress(valAddr))
 		if err != nil {
 			return nil, err
 		}
 
-		err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, withdrawAddr, commission)
+		err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, dest.ResolvedWithdrawAddr, commission)
 		if err != nil {
 			return nil, err
 		}

--- a/x/distribution/keeper/keeper_test.go
+++ b/x/distribution/keeper/keeper_test.go
@@ -10,17 +10,20 @@ import (
 
 	"cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtestutil "github.com/cosmos/cosmos-sdk/x/distribution/testutil"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 func TestSetWithdrawAddr(t *testing.T) {
@@ -86,6 +89,9 @@ func TestWithdrawValidatorCommission(t *testing.T) {
 	accountKeeper := distrtestutil.NewMockAccountKeeper(ctrl)
 
 	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
+	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
+	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+	bankKeeper.EXPECT().BlockedAddr(gomock.Any()).Return(false).AnyTimes()
 
 	valCommission := sdk.DecCoins{
 		sdk.NewDecCoinFromDec("mytoken", math.LegacyNewDec(5).Quo(math.LegacyNewDec(4))),
@@ -124,6 +130,122 @@ func TestWithdrawValidatorCommission(t *testing.T) {
 		sdk.NewDecCoinFromDec("mytoken", math.LegacyNewDec(1).Quo(math.LegacyNewDec(4))),
 		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(1).Quo(math.LegacyNewDec(2))),
 	}, remainder)
+}
+
+func TestWithdrawValidatorCommission_BlockedWithdrawAddress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	key := storetypes.NewKVStoreKey(types.StoreKey)
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	encCfg := moduletestutil.MakeTestEncodingConfig(distribution.AppModuleBasic{})
+	ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Time: time.Now()})
+	addrs := simtestutil.CreateIncrementalAccounts(2)
+
+	valAddr := sdk.ValAddress(addrs[0])
+	accAddr := sdk.AccAddress(valAddr)
+	blockedAddr := addrs[1]
+
+	bankKeeper := distrtestutil.NewMockBankKeeper(ctrl)
+	stakingKeeper := distrtestutil.NewMockStakingKeeper(ctrl)
+	accountKeeper := distrtestutil.NewMockAccountKeeper(ctrl)
+
+	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
+	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
+	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+
+	valCommission := sdk.DecCoins{
+		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(3).Quo(math.LegacyNewDec(2))),
+	}
+
+	distrKeeper := keeper.NewKeeper(
+		encCfg.Codec,
+		storeService,
+		accountKeeper,
+		bankKeeper,
+		stakingKeeper,
+		"fee_collector",
+		authtypes.NewModuleAddress("gov").String(),
+	)
+
+	require.NoError(t, distrKeeper.SetValidatorOutstandingRewards(ctx, valAddr, types.ValidatorOutstandingRewards{Rewards: valCommission}))
+	require.NoError(t, distrKeeper.SetValidatorAccumulatedCommission(ctx, valAddr, types.ValidatorAccumulatedCommission{Commission: valCommission}))
+
+	// point validator's withdraw address at a blocked address
+	require.NoError(t, distrKeeper.Params.Set(ctx, types.DefaultParams()))
+	bankKeeper.EXPECT().BlockedAddr(blockedAddr).Return(false).Times(1) // allow SetWithdrawAddr to succeed
+	require.NoError(t, distrKeeper.SetWithdrawAddr(ctx, accAddr, blockedAddr))
+
+	// strict resolver sees the addr as blocked and errors. Any partial state
+	// mutation done before the bank send is rolled back at the tx level by the
+	// msg server's cache context, so we don't assert keeper-level state here.
+	bankKeeper.EXPECT().BlockedAddr(blockedAddr).Return(true).Times(1)
+
+	sdkCtx := ctx.WithEventManager(sdk.NewEventManager())
+	_, err := distrKeeper.WithdrawValidatorCommission(sdkCtx, valAddr)
+	require.ErrorIs(t, err, sdkerrors.ErrUnauthorized)
+}
+
+func TestWithdrawDelegationRewards_BlockedWithdrawAddress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	key := storetypes.NewKVStoreKey(types.StoreKey)
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	encCfg := moduletestutil.MakeTestEncodingConfig(distribution.AppModuleBasic{})
+	ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Height: 1})
+
+	bankKeeper := distrtestutil.NewMockBankKeeper(ctrl)
+	stakingKeeper := distrtestutil.NewMockStakingKeeper(ctrl)
+	accountKeeper := distrtestutil.NewMockAccountKeeper(ctrl)
+
+	accountKeeper.EXPECT().GetModuleAddress("distribution").Return(distrAcc.GetAddress())
+	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixValAddr)).AnyTimes()
+	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec(sdk.Bech32MainPrefix)).AnyTimes()
+
+	distrKeeper := keeper.NewKeeper(
+		encCfg.Codec,
+		storeService,
+		accountKeeper,
+		bankKeeper,
+		stakingKeeper,
+		"fee_collector",
+		authtypes.NewModuleAddress("gov").String(),
+	)
+
+	require.NoError(t, distrKeeper.FeePool.Set(ctx, types.InitialFeePool()))
+	require.NoError(t, distrKeeper.Params.Set(ctx, types.DefaultParams()))
+
+	valAddr := sdk.ValAddress(valConsAddr0)
+	addr := sdk.AccAddress(valAddr)
+	val, err := distrtestutil.CreateValidator(valConsPk0, math.NewInt(100))
+	require.NoError(t, err)
+	val.Commission = stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyNewDecWithPrec(5, 1), math.LegacyNewDec(0))
+
+	del := stakingtypes.NewDelegation(addr.String(), valAddr.String(), val.DelegatorShares)
+	stakingKeeper.EXPECT().Validator(gomock.Any(), valAddr).Return(val, nil).AnyTimes()
+	stakingKeeper.EXPECT().Delegation(gomock.Any(), addr, valAddr).Return(del, nil).AnyTimes()
+
+	require.NoError(t, distrtestutil.CallCreateValidatorHooks(ctx, distrKeeper, addr, valAddr))
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+	// set withdraw address to address that we will block
+	blockedAddr := sdk.AccAddress(valConsAddr1)
+	require.NoError(t, distrKeeper.SetDelegatorWithdrawAddr(ctx, addr, blockedAddr))
+
+	// allocate rewards so there's something to withdraw
+	initial := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+	tokens := sdk.DecCoins{sdk.NewDecCoin(sdk.DefaultBondDenom, initial)}
+	require.NoError(t, distrKeeper.AllocateTokensToValidator(ctx, val, tokens))
+
+	// blocked addr is now blocked in the bank keeper
+	bankKeeper.EXPECT().BlockedAddr(blockedAddr).Return(true).Times(1)
+
+	// reset events so we can assert just the ones from this call
+	sdkCtx := ctx.WithEventManager(sdk.NewEventManager())
+
+	// try and withdraw rewards.
+	_, err = distrKeeper.WithdrawDelegationRewards(sdkCtx, addr, valAddr)
+	require.ErrorIs(t, err, sdkerrors.ErrUnauthorized)
 }
 
 func TestGetTotalRewards(t *testing.T) {

--- a/x/distribution/types/events.go
+++ b/x/distribution/types/events.go
@@ -2,14 +2,18 @@ package types
 
 // distribution module event types
 const (
-	EventTypeSetWithdrawAddress = "set_withdraw_address"
-	EventTypeRewards            = "rewards"
-	EventTypeCommission         = "commission"
-	EventTypeWithdrawRewards    = "withdraw_rewards"
-	EventTypeWithdrawCommission = "withdraw_commission"
-	EventTypeProposerReward     = "proposer_reward"
+	EventTypeSetWithdrawAddress     = "set_withdraw_address"
+	EventTypeRewards                = "rewards"
+	EventTypeCommission             = "commission"
+	EventTypeWithdrawRewards        = "withdraw_rewards"
+	EventTypeWithdrawCommission     = "withdraw_commission"
+	EventTypeProposerReward         = "proposer_reward"
+	EventTypeWithdrawAddrRedirected = "withdraw_addr_redirected"
 
-	AttributeKeyWithdrawAddress = "withdraw_address"
-	AttributeKeyValidator       = "validator"
-	AttributeKeyDelegator       = "delegator"
+	AttributeKeyWithdrawAddress         = "withdraw_address"
+	AttributeKeyValidator               = "validator"
+	AttributeKeyDelegator               = "delegator"
+	AttributeKeyOriginalWithdrawAddress = "original_withdraw_address"
+
+	AttributeValueCommunityPool = "community_pool"
 )

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -276,6 +276,7 @@ func (k msgServer) Delegate(ctx context.Context, msg *types.MsgDelegate) (*types
 	}
 
 	// NOTE: source funds are always unbonded
+	ctx = types.WithStrictWithdraw(ctx)
 	newShares, err := k.Keeper.Delegate(ctx, delegatorAddress, msg.Amount.Amount, types.Unbonded, validator, true)
 	if err != nil {
 		return nil, err
@@ -348,6 +349,7 @@ func (k msgServer) BeginRedelegate(ctx context.Context, msg *types.MsgBeginRedel
 		)
 	}
 
+	ctx = types.WithStrictWithdraw(ctx)
 	completionTime, err := k.BeginRedelegation(
 		ctx, delegatorAddress, valSrcAddr, valDstAddr, shares,
 	)
@@ -420,6 +422,7 @@ func (k msgServer) Undelegate(ctx context.Context, msg *types.MsgUndelegate) (*t
 		)
 	}
 
+	ctx = types.WithStrictWithdraw(ctx)
 	completionTime, undelegatedAmt, err := k.Keeper.Undelegate(ctx, delegatorAddress, addr, shares)
 	if err != nil {
 		return nil, err
@@ -544,6 +547,7 @@ func (k msgServer) CancelUnbondingDelegation(ctx context.Context, msg *types.Msg
 	}
 
 	// delegate back the unbonding delegation amount to the validator
+	ctx = types.WithStrictWithdraw(ctx)
 	_, err = k.Keeper.Delegate(ctx, delegatorAddress, msg.Amount.Amount, types.Unbonding, validator, false)
 	if err != nil {
 		return nil, err

--- a/x/staking/types/context.go
+++ b/x/staking/types/context.go
@@ -1,0 +1,18 @@
+package types
+
+import "context"
+
+// strictWithdrawCtxKey marks a context as originating from a user tx, signaling
+// to downstream hooks that errors should propagate instead of falling back.
+type strictWithdrawCtxKey struct{}
+
+// WithStrictWithdraw marks ctx so hooks propagate errors instead of falling back.
+func WithStrictWithdraw(ctx context.Context) context.Context {
+	return context.WithValue(ctx, strictWithdrawCtxKey{}, true)
+}
+
+// IsStrictWithdraw reports whether ctx was marked by WithStrictWithdraw.
+func IsStrictWithdraw(ctx context.Context) bool {
+	v, _ := ctx.Value(strictWithdrawCtxKey{}).(bool)
+	return v
+}


### PR DESCRIPTION
### Problem

Reward and commission withdrawals inside `Begin`/`EndBlocker` (staking hooks) sent coins directly to a delegator's or validator's withdraw address. If that address was on the bank module's blocked-address list, the send failed. Since this happens outside a user-initiated message, there was no way to recover: the withdrawal kept failing every block.

This includes withdrawals triggered during slashing: `SlashRedelegation` calls `Unbond`, which fires the same reward-withdrawal hook. Before this fix, a blocked withdraw address hit during downtime jailing or equivocation evidence handling would halt the chain, not just during ordinary reward payout.

### Fix

Backport of [cosmos/cosmos-sdk#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) ([196b5a3](https://github.com/cosmos/cosmos-sdk/commit/196b5a347216f982f0020bdd3f95e8eebe614290)):

- Adds a withdraw-destination resolver in `x/distribution` that, outside of message handling, falls back from the withdraw address to the delegator/validator owner address, and finally to the community pool, if the preferred destination is blocked.
- Emits a new event when a withdrawal gets redirected away from its normal destination.
- Message-initiated withdrawals (`Delegate`, `BeginRedelegate`, `Undelegate`, `CancelUnbondingDelegation` in `x/staking`) keep the old strict behavior: they still return `ErrUnauthorized` if the destination is blocked, so the user finds out immediately and can fix their withdraw address instead of silently losing funds to the community pool. This is done via a new `x/staking/types/context.go` context flag (`WithStrictWithdraw`/`IsStrictWithdraw`) that `x/distribution` checks before falling back.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
