### PR TITLE
fix(x/auth/tx): avoid nil pointer panic in GetSigningTxData for multisig ModeInfo with a nil Multi or nil Bitarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (x/auth/tx) [#26571](https://github.com/cosmos/cosmos-sdk/pull/26571) Avoid nil pointer panic in `GetSigningTxData` for multisig `ModeInfo` with a nil `Multi` or nil `Bitarray`.
 * (simulation) [#1817](https://github.com/crypto-org-chain/cosmos-sdk/pull/1817) Disable `SimWriteState` for ethermint compatibility (backport #1760).
 * (baseapp) [#1816](https://github.com/crypto-org-chain/cosmos-sdk/pull/1816) Close multistore opened for historical queries (backport #1808).
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.

--- a/x/auth/tx/adapter.go
+++ b/x/auth/tx/adapter.go
@@ -123,17 +123,25 @@ func adaptModeInfo(legacy *tx.ModeInfo, res *txv1beta1.ModeInfo) {
 			},
 		}
 	case *tx.ModeInfo_Multi_:
-		multiModeInfos := legacy.GetMulti().ModeInfos
+		if mi.Multi == nil {
+			res.Sum = &txv1beta1.ModeInfo_Multi_{Multi: &txv1beta1.ModeInfo_Multi{}}
+			return
+		}
+		multiModeInfos := mi.Multi.ModeInfos
 		modeInfos := make([]*txv1beta1.ModeInfo, len(multiModeInfos))
 		for _, modeInfo := range multiModeInfos {
 			adaptModeInfo(modeInfo, &txv1beta1.ModeInfo{})
 		}
+		var bitarray *multisigv1beta1.CompactBitArray
+		if mi.Multi.Bitarray != nil {
+			bitarray = &multisigv1beta1.CompactBitArray{
+				Elems:           mi.Multi.Bitarray.Elems,
+				ExtraBitsStored: mi.Multi.Bitarray.ExtraBitsStored,
+			}
+		}
 		res.Sum = &txv1beta1.ModeInfo_Multi_{
 			Multi: &txv1beta1.ModeInfo_Multi{
-				Bitarray: &multisigv1beta1.CompactBitArray{
-					Elems:           mi.Multi.Bitarray.Elems,
-					ExtraBitsStored: mi.Multi.Bitarray.ExtraBitsStored,
-				},
+				Bitarray:  bitarray,
 				ModeInfos: modeInfos,
 			},
 		}

--- a/x/auth/tx/builder_test.go
+++ b/x/auth/tx/builder_test.go
@@ -361,3 +361,64 @@ func TestBuilderWithTimeoutTimestamp(t *testing.T) {
 	b := txBldr.(*wrapper)
 	require.True(t, b.tx.Body.TimeoutTimestamp.Equal(timeoutTimestamp))
 }
+
+func TestGetSigningTxData_NilMultiBitarray(t *testing.T) {
+	_, pubkey, addr := testdata.KeyTestPubAddr()
+
+	marshaler := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	w := newBuilder(marshaler)
+
+	require.NoError(t, w.SetMsgs(testdata.NewTestMsg(addr)))
+	any, err := codectypes.NewAnyWithValue(pubkey)
+	require.NoError(t, err)
+
+	// Inject a SignerInfo with ModeInfo_Multi whose Bitarray is nil — valid
+	// wire state that survives decoding if the field is omitted. Before the
+	// fix, adaptModeInfo would dereference nil and panic.
+	w.tx.AuthInfo.SignerInfos = []*txtypes.SignerInfo{
+		{
+			PublicKey: any,
+			ModeInfo: &txtypes.ModeInfo{
+				Sum: &txtypes.ModeInfo_Multi_{
+					Multi: &txtypes.ModeInfo_Multi{
+						Bitarray: nil,
+					},
+				},
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		td := w.GetSigningTxData()
+		require.Len(t, td.AuthInfo.SignerInfos, 1)
+		require.Nil(t, td.AuthInfo.SignerInfos[0].ModeInfo.GetMulti().Bitarray)
+	})
+}
+
+func TestGetSigningTxData_NilModeInfoMulti(t *testing.T) {
+	_, pubkey, addr := testdata.KeyTestPubAddr()
+
+	marshaler := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	w := newBuilder(marshaler)
+
+	require.NoError(t, w.SetMsgs(testdata.NewTestMsg(addr)))
+	any, err := codectypes.NewAnyWithValue(pubkey)
+	require.NoError(t, err)
+
+	w.tx.AuthInfo.SignerInfos = []*txtypes.SignerInfo{
+		{
+			PublicKey: any,
+			ModeInfo: &txtypes.ModeInfo{
+				Sum: &txtypes.ModeInfo_Multi_{
+					Multi: nil,
+				},
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		td := w.GetSigningTxData()
+		require.Len(t, td.AuthInfo.SignerInfos, 1)
+		require.NotNil(t, td.AuthInfo.SignerInfos[0].ModeInfo.GetMulti())
+	})
+}


### PR DESCRIPTION
### Problem

`adaptModeInfo` in `x/auth/tx/adapter.go` converts a legacy `ModeInfo` into the `x/tx` API representation. For the multisig case (`ModeInfo_Multi_`), it dereferenced `mi.Multi.Bitarray.Elems` and `mi.Multi.Bitarray.ExtraBitsStored` without checking whether `Multi` or `Bitarray` were nil.

Both fields are attacker-controlled: a decoded transaction can carry a `SignerInfo` with `ModeInfo_Multi_{Multi: nil}` or a `Multi` with a nil `Bitarray`, and this is valid wire state (proto3 message fields are always optional). `GetSigningTxData` is called before signature verification, so a crafted tx with either shape crashes the node with a nil pointer panic.

This backports the fix from the still-open upstream PR [cosmos/cosmos-sdk#26571](https://github.com/cosmos/cosmos-sdk/pull/26571) (no commit to cherry-pick yet, so the diff was applied directly).

### Fix

- In `adaptModeInfo`, return early with an empty `ModeInfo_Multi` when `mi.Multi` is nil.
- Only build the `Bitarray` when `mi.Multi.Bitarray` is non-nil; otherwise leave it nil.
- Add two tests covering a nil `Bitarray` and a nil `Multi`, asserting `GetSigningTxData` does not panic.

This fork's `x/auth/tx/builder_test.go` doesn't yet have the nil-`PublicKey` guard from [#26527](https://github.com/cosmos/cosmos-sdk/pull/26527), so the new tests set a `PublicKey` on the injected `SignerInfo` to isolate the `Multi`/`Bitarray` behavior from that unrelated, already-existing gap.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments