### PR TITLE
fix(server): lower default gRPC MaxSendMsgSize from ~2GB to 10MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (server) [#26585](https://github.com/cosmos/cosmos-sdk/pull/26585) lower default gRPC MaxSendMsgSize from ~2GB to 10MB
+
 ### Deprecated
 
 ## [v0.54.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.3) - 2026-05-05

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
@@ -29,7 +28,7 @@ const (
 
 	// DefaultGRPCMaxSendMsgSize defines the default gRPC max message size in
 	// bytes the server can send.
-	DefaultGRPCMaxSendMsgSize = math.MaxInt32
+	DefaultGRPCMaxSendMsgSize = 1024 * 1024 * 10
 )
 
 // BaseConfig defines the server's basic configuration
@@ -153,7 +152,7 @@ type GRPCConfig struct {
 	MaxRecvMsgSize int `mapstructure:"max-recv-msg-size"`
 
 	// MaxSendMsgSize defines the max message size in bytes the server can send.
-	// The default value is math.MaxInt32.
+	// The default value is 10MB.
 	MaxSendMsgSize int `mapstructure:"max-send-msg-size"`
 
 	// SkipCheckHeader defines if the gRPC server should bypass header checking.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -183,7 +183,7 @@ address = "{{ .GRPC.Address }}"
 max-recv-msg-size = "{{ .GRPC.MaxRecvMsgSize }}"
 
 # MaxSendMsgSize defines the max message size in bytes the server can send.
-# The default value is math.MaxInt32.
+# The default value is 10MB.
 max-send-msg-size = "{{ .GRPC.MaxSendMsgSize }}"
 
 # Historical gRPC addresses with block ranges for historical query routing.


### PR DESCRIPTION
### Problem

The gRPC server's default `MaxSendMsgSize` was `math.MaxInt32` (about 2GB). Any query handler that builds a large response, such as a big paginated list or a large genesis export, could make the server buffer and send a message that size. A client can trigger this just by asking for enough data back, turning normal query traffic into a way to pressure the node's memory.

The matching `MaxRecvMsgSize` default was already a sane 10MB. There was no reason for the send side to allow about 200x more.

### Fix

- Lower `DefaultGRPCMaxSendMsgSize` in `server/config/config.go` from `math.MaxInt32` to `1024 * 1024 * 10` (10MB), matching `MaxRecvMsgSize`.
- Update the doc comment on the constant and the `app.toml` template comment in `server/config/toml.go` to describe the new default instead of `math.MaxInt32`.
- Remove the now-unused `math` import.
- This is only a default. Operators who need larger responses can still raise `grpc.max-send-msg-size` in `app.toml`.

This backports [cosmos/cosmos-sdk#26585](https://github.com/cosmos/cosmos-sdk/pull/26585) to release/v0.54.x.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments