### PR TITLE
fix(x/staking): propagate AfterUnbondingInitiated hook error instead of swallowing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (x/staking) [#26589](https://github.com/cosmos/cosmos-sdk/pull/26589) propagate AfterUnbondingInitiated hook error instead of swallowing it
+
 ### Deprecated
 
 ## [v0.54.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.3) - 2026-05-05

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -457,7 +457,7 @@ func (k Keeper) SetUnbondingDelegationEntry(
 		}
 
 		if err := k.Hooks().AfterUnbondingInitiated(ctx, id); err != nil {
-			k.Logger(ctx).Error("failed to call after unbonding initiated hook", "error", err)
+			return ubd, err
 		}
 	}
 	return ubd, nil
@@ -725,8 +725,7 @@ func (k Keeper) SetRedelegationEntry(ctx context.Context,
 	}
 
 	if err := k.Hooks().AfterUnbondingInitiated(ctx, id); err != nil {
-		k.Logger(ctx).Error("failed to call after unbonding initiated hook", "error", err)
-		// TODO (Facu): Should we return here? We are ignoring this error
+		return types.Redelegation{}, err
 	}
 
 	return red, nil

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"time"
 
 	"go.uber.org/mock/gomock"
@@ -1240,4 +1241,57 @@ func (s *KeeperTestSuite) TestSetUnbondingDelegationEntry() {
 	// unbondingID == 1 was skipped because the entry was merged with the existing entry with unbondingID == 0
 	// unbondingID comes from a global counter -> gaps in unbondingIDs are OK as long as every unbondingID is unique
 	require.Equal(uint64(2), resUnbonding.Entries[1].UnbondingId)
+}
+
+func (s *KeeperTestSuite) TestSetUnbondingDelegationEntryHookError() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	delAddrs, valAddrs := createValAddrs(1)
+	delAddr := delAddrs[0]
+	valAddr := valAddrs[0]
+
+	hookErr := errors.New("hook failed")
+	ctrl := gomock.NewController(s.T())
+	hooks := testutil.NewMockStakingHooks(ctrl)
+	hooks.EXPECT().AfterUnbondingInitiated(gomock.Any(), gomock.Any()).Return(hookErr)
+	keeper.SetHooks(hooks)
+
+	_, err := keeper.SetUnbondingDelegationEntry(
+		ctx,
+		delAddr,
+		valAddr,
+		0,
+		time.Unix(0, 0).UTC(),
+		math.NewInt(5),
+	)
+	require.ErrorIs(err, hookErr)
+}
+
+func (s *KeeperTestSuite) TestSetRedelegationEntryHookError() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	delAddrs, valAddrs := createValAddrs(2)
+	delAddr := delAddrs[0]
+	valSrcAddr, valDstAddr := valAddrs[0], valAddrs[1]
+
+	hookErr := errors.New("hook failed")
+	ctrl := gomock.NewController(s.T())
+	hooks := testutil.NewMockStakingHooks(ctrl)
+	hooks.EXPECT().AfterUnbondingInitiated(gomock.Any(), gomock.Any()).Return(hookErr)
+	keeper.SetHooks(hooks)
+
+	_, err := keeper.SetRedelegationEntry(
+		ctx,
+		delAddr,
+		valSrcAddr,
+		valDstAddr,
+		0,
+		time.Unix(0, 0).UTC(),
+		math.NewInt(5),
+		math.LegacyNewDec(5),
+		math.LegacyNewDec(5),
+	)
+	require.ErrorIs(err, hookErr)
 }


### PR DESCRIPTION
### Problem

In `x/staking/keeper/delegation.go`, both `SetUnbondingDelegationEntry` and `SetRedelegationEntry` call the `AfterUnbondingInitiated` hook and silently discard any error it returns, each with a stale `TODO` noting this was wrong. Any module relying on this hook (for example slashing or liquid-staking integrations) can fail without the failure ever surfacing to the caller or the chain.

This was already inconsistent with `BeginUnbondingValidator` (`val_state_change.go`), which correctly returns this same hook's error.

### Fix

- `SetUnbondingDelegationEntry` and `SetRedelegationEntry` now return the hook error instead of swallowing it.
- Removed the stale `TODO` comment in `SetRedelegationEntry`.
- Added `TestSetUnbondingDelegationEntryHookError` and `TestSetRedelegationEntryHookError`, each using a gomock `MockStakingHooks` to force a hook error and asserting it is returned.
- Verified every existing caller of both functions (in `Undelegate` and `BeginRedelegation`) already checks and propagates a non-nil error through the normal msg-server error path, so this cannot introduce a panic or unhandled abort — it just makes an existing failure visible instead of silent.

This branch's `x/staking/keeper/delegation.go` has diverged from upstream with a pending-slots queue optimization (`GetUBDQueuePendingSlots`, `AddUBDQueuePendingSlot`, `PopulateQueuePendingSlots`, and related changes to `SetUBDQueueTimeSlice` / `DequeueAllMatureUBDQueue`) that is not present upstream. That refactor does not touch the two hook call sites themselves, but it meant a blind cherry-pick would risk landing on stale surrounding code, so the fix was hand-applied to the current file instead.

This backports [cosmos/cosmos-sdk#26589](https://github.com/cosmos/cosmos-sdk/pull/26589) to release/v0.54.x. Hand-ported (not a clean cherry-pick) because this branch's x/staking/keeper/delegation.go has diverged with a pending-slots queue optimization not present upstream.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments