### PR TITLE
fix(codec,x/tx): lower nested Any depth cap from 10000 to 64 to reduce DoS amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (codec,x/tx) [#26587](https://github.com/cosmos/cosmos-sdk/pull/26587) lower nested Any depth cap from 10000 to 64 to reduce DoS amplification
+
 ### Deprecated
 
 ## [v0.54.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.3) - 2026-05-05

--- a/codec/unknownproto/unknown_fields.go
+++ b/codec/unknownproto/unknown_fields.go
@@ -21,11 +21,9 @@ import (
 
 const bit11NonCritical = 1 << 10
 
-// maxAnyNestingDepth bounds recursion into nested google.protobuf.Any values.
-// Each level costs 3 passes over the remaining bytes (reject-unknown scan,
-// Any unmarshal, and recursion into the resolved message), so an attacker
-// controlling nesting depth can otherwise force O(depth×size) CPU work from a
-// single tx. No legitimate message nests Any more than a few levels deep.
+// maxAnyNestingDepth caps message-recursion depth. Each level re-scans the
+// remaining bytes, so a chain of google.protobuf.Any redirections could force
+// O(depth*size) CPU from a single tx; 64 far exceeds any legitimate nesting.
 const maxAnyNestingDepth = 64
 
 type descriptorIface interface {

--- a/codec/unknownproto/unknown_fields.go
+++ b/codec/unknownproto/unknown_fields.go
@@ -21,6 +21,13 @@ import (
 
 const bit11NonCritical = 1 << 10
 
+// maxAnyNestingDepth bounds recursion into nested google.protobuf.Any values.
+// Each level costs 3 passes over the remaining bytes (reject-unknown scan,
+// Any unmarshal, and recursion into the resolved message), so an attacker
+// controlling nesting depth can otherwise force O(depth×size) CPU work from a
+// single tx. No legitimate message nests Any more than a few levels deep.
+const maxAnyNestingDepth = 64
+
 type descriptorIface interface {
 	Descriptor() ([]byte, []int)
 }
@@ -40,8 +47,7 @@ func RejectUnknownFieldsStrict(bz []byte, msg proto.Message, resolver jsonpb.Any
 // This function traverses inside of messages nested via google.protobuf.Any. It does not do any deserialization of the proto.Message.
 // An AnyResolver must be provided for traversing inside google.protobuf.Any's.
 func RejectUnknownFields(bz []byte, msg proto.Message, allowUnknownNonCriticals bool, resolver jsonpb.AnyResolver) (hasUnknownNonCriticals bool, err error) {
-	// recursion limit with same default as https://github.com/protocolbuffers/protobuf-go/blob/v1.35.2/encoding/protowire/wire.go#L28
-	return doRejectUnknownFields(bz, msg, allowUnknownNonCriticals, resolver, 10_000)
+	return doRejectUnknownFields(bz, msg, allowUnknownNonCriticals, resolver, maxAnyNestingDepth)
 }
 
 func doRejectUnknownFields(

--- a/codec/unknownproto/unknown_fields.go
+++ b/codec/unknownproto/unknown_fields.go
@@ -21,9 +21,7 @@ import (
 
 const bit11NonCritical = 1 << 10
 
-// maxAnyNestingDepth caps message-recursion depth. Each level re-scans the
-// remaining bytes, so a chain of google.protobuf.Any redirections could force
-// O(depth*size) CPU from a single tx; 64 far exceeds any legitimate nesting.
+// maxAnyNestingDepth caps recursion cost from chained Any redirections; 64 exceeds any legitimate nesting.
 const maxAnyNestingDepth = 64
 
 type descriptorIface interface {

--- a/x/tx/decode/unknown.go
+++ b/x/tx/decode/unknown.go
@@ -14,6 +14,13 @@ import (
 
 const bit11NonCritical = 1 << 10
 
+// maxAnyNestingDepth bounds recursion into nested google.protobuf.Any values.
+// Each level costs 3 passes over the remaining bytes (reject-unknown scan,
+// Any unmarshal, and recursion into the resolved message), so an attacker
+// controlling nesting depth can otherwise force O(depth×size) CPU work from a
+// single tx. No legitimate message nests Any more than a few levels deep.
+const maxAnyNestingDepth = 64
+
 var (
 	anyDesc     = (&anypb.Any{}).ProtoReflect().Descriptor()
 	anyFullName = anyDesc.FullName()
@@ -33,8 +40,7 @@ func RejectUnknownFieldsStrict(bz []byte, msg protoreflect.MessageDescriptor, re
 // This function traverses inside of messages nested via google.protobuf.Any. It does not do any deserialization of the proto.Message.
 // An AnyResolver must be provided for traversing inside google.protobuf.Any's.
 func RejectUnknownFields(bz []byte, desc protoreflect.MessageDescriptor, allowUnknownNonCriticals bool, resolver protodesc.Resolver) (hasUnknownNonCriticals bool, err error) {
-	// recursion limit with same default as https://github.com/protocolbuffers/protobuf-go/blob/v1.35.2/encoding/protowire/wire.go#L28
-	return doRejectUnknownFields(bz, desc, allowUnknownNonCriticals, resolver, 10_000)
+	return doRejectUnknownFields(bz, desc, allowUnknownNonCriticals, resolver, maxAnyNestingDepth)
 }
 
 func doRejectUnknownFields(

--- a/x/tx/decode/unknown.go
+++ b/x/tx/decode/unknown.go
@@ -14,11 +14,9 @@ import (
 
 const bit11NonCritical = 1 << 10
 
-// maxAnyNestingDepth bounds recursion into nested google.protobuf.Any values.
-// Each level costs 3 passes over the remaining bytes (reject-unknown scan,
-// Any unmarshal, and recursion into the resolved message), so an attacker
-// controlling nesting depth can otherwise force O(depth×size) CPU work from a
-// single tx. No legitimate message nests Any more than a few levels deep.
+// maxAnyNestingDepth caps message-recursion depth. Each level re-scans the
+// remaining bytes, so a chain of google.protobuf.Any redirections could force
+// O(depth*size) CPU from a single tx; 64 far exceeds any legitimate nesting.
 const maxAnyNestingDepth = 64
 
 var (

--- a/x/tx/decode/unknown.go
+++ b/x/tx/decode/unknown.go
@@ -14,9 +14,7 @@ import (
 
 const bit11NonCritical = 1 << 10
 
-// maxAnyNestingDepth caps message-recursion depth. Each level re-scans the
-// remaining bytes, so a chain of google.protobuf.Any redirections could force
-// O(depth*size) CPU from a single tx; 64 far exceeds any legitimate nesting.
+// maxAnyNestingDepth caps recursion cost from chained Any redirections; 64 exceeds any legitimate nesting.
 const maxAnyNestingDepth = 64
 
 var (


### PR DESCRIPTION
### Problem

`codec/unknownproto/unknown_fields.go` and its sibling `x/tx/decode/unknown.go` both validate messages by recursing into nested `google.protobuf.Any` values, guarded by a recursion-depth limit of `10_000`. That cap is deep enough that a maliciously nested message can still force thousands of recursive validation passes. It's cheap for an attacker to build such a message, but expensive for a node to process, before the cap finally kicks in.

### Fix

- Replace the inline `10_000` in both files with a named constant `maxAnyNestingDepth = 64`, with a short comment explaining that nesting multiplies validation cost and that 64 is deliberately generous relative to any legitimate message shape used across the SDK.
- Keep both implementations in sync: the constant, its wiring, and the depth semantics are now identical in both packages.

This backports [cosmos/cosmos-sdk#26587](https://github.com/cosmos/cosmos-sdk/pull/26587) to release/v0.54.x.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments