### PR TITLE
fix(x/authz): cap expired grant pruning per BeginBlocker to 200, matching feegrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (x/authz) [#26588](https://github.com/cosmos/cosmos-sdk/pull/26588) cap expired grant pruning per BeginBlocker to 200, matching feegrant
+
 ### Deprecated
 
 ## [v0.54.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.3) - 2026-05-05

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -412,8 +412,10 @@ func (k Keeper) removeFromGrantQueue(ctx context.Context, grantKey []byte, grant
 	return nil
 }
 
-// DequeueAndDeleteExpiredGrants deletes expired grants from the state and grant queue.
-func (k Keeper) DequeueAndDeleteExpiredGrants(ctx context.Context) error {
+// DequeueAndDeleteExpiredGrants deletes expired grants from the state and grant queue,
+// stopping once limit grants have been deleted. Remaining expired grants are left for
+// the next call so a single block with many expirations can't do unbounded work.
+func (k Keeper) DequeueAndDeleteExpiredGrants(ctx context.Context, limit int32) error {
 	store := k.storeService.OpenKVStore(ctx)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
@@ -423,7 +425,12 @@ func (k Keeper) DequeueAndDeleteExpiredGrants(ctx context.Context) error {
 	}
 	defer iterator.Close()
 
+	count := int32(0)
 	for ; iterator.Valid(); iterator.Next() {
+		if count == limit {
+			break
+		}
+
 		var queueItem authz.GrantQueueItem
 		if err := k.cdc.Unmarshal(iterator.Value(), &queueItem); err != nil {
 			return err
@@ -445,6 +452,8 @@ func (k Keeper) DequeueAndDeleteExpiredGrants(ctx context.Context) error {
 				return err
 			}
 		}
+
+		count++
 	}
 
 	return nil

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -412,9 +412,8 @@ func (k Keeper) removeFromGrantQueue(ctx context.Context, grantKey []byte, grant
 	return nil
 }
 
-// DequeueAndDeleteExpiredGrants deletes expired grants from the state and grant queue,
-// stopping once limit grants have been deleted. Remaining expired grants are left for
-// the next call so a single block with many expirations can't do unbounded work.
+// DequeueAndDeleteExpiredGrants deletes expired grants, capped at limit per call; any
+// remainder is picked up by the next call, bounding per-block work.
 func (k Keeper) DequeueAndDeleteExpiredGrants(ctx context.Context, limit int32) error {
 	store := k.storeService.OpenKVStore(ctx)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)

--- a/x/authz/keeper/keeper_test.go
+++ b/x/authz/keeper/keeper_test.go
@@ -382,7 +382,7 @@ func (s *TestSuite) TestDequeueAllGrantsQueue() {
 	require.NoError(err)
 
 	newCtx := s.ctx.WithBlockTime(exp.AddDate(1, 0, 0))
-	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx)
+	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 200)
 	require.NoError(err)
 
 	s.T().Log("verify expired grants are pruned from the state")

--- a/x/authz/keeper/keeper_test.go
+++ b/x/authz/keeper/keeper_test.go
@@ -403,6 +403,46 @@ func (s *TestSuite) TestDequeueAllGrantsQueue() {
 	require.Len(authzs, 1)
 }
 
+func (s *TestSuite) TestDequeueAndDeleteExpiredGrantsCapsPerCall() {
+	require := s.Require()
+	addrs := s.addrs
+	exp := s.ctx.BlockTime().AddDate(0, 0, 1)
+	a := banktypes.SendAuthorization{SpendLimit: coins100}
+
+	// three grants sharing one expiration, between distinct granter/grantee pairs
+	pairs := [][2]sdk.AccAddress{
+		{addrs[0], addrs[1]},
+		{addrs[2], addrs[3]},
+		{addrs[4], addrs[5]},
+	}
+	for _, p := range pairs {
+		err := s.authzKeeper.SaveGrant(s.ctx, p[1], p[0], &a, &exp)
+		require.NoError(err)
+	}
+
+	newCtx := s.ctx.WithBlockTime(exp.AddDate(0, 0, 1))
+
+	remaining := func() int {
+		n := 0
+		for _, p := range pairs {
+			authzs, err := s.authzKeeper.GetAuthorizations(newCtx, p[1], p[0])
+			require.NoError(err)
+			n += len(authzs)
+		}
+		return n
+	}
+
+	// first call only prunes up to the limit, leaving the rest for the next call to resume
+	err := s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 2)
+	require.NoError(err)
+	require.Equal(1, remaining(), "expected exactly one grant left after pruning capped at 2 of 3")
+
+	// second call drains what's left
+	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 2)
+	require.NoError(err)
+	require.Equal(0, remaining(), "expected no grants left after the backlog is fully drained")
+}
+
 func (s *TestSuite) TestGetAuthorization() {
 	addr1 := s.addrs[3]
 	addr2 := s.addrs[4]

--- a/x/authz/module/abci.go
+++ b/x/authz/module/abci.go
@@ -7,6 +7,6 @@ import (
 
 // BeginBlocker is called at the beginning of every block
 func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) error {
-	// delete mature grants, capped per block; 200 is an arbitrary value, we can change it later if needed
+	// capped per block to bound pruning work; 200 is arbitrary
 	return keeper.DequeueAndDeleteExpiredGrants(ctx, 200)
 }

--- a/x/authz/module/abci.go
+++ b/x/authz/module/abci.go
@@ -7,6 +7,6 @@ import (
 
 // BeginBlocker is called at the beginning of every block
 func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) error {
-	// delete all the mature grants
-	return keeper.DequeueAndDeleteExpiredGrants(ctx)
+	// delete mature grants, capped per block; 200 is an arbitrary value, we can change it later if needed
+	return keeper.DequeueAndDeleteExpiredGrants(ctx, 200)
 }


### PR DESCRIPTION
### Problem

`x/authz`'s `BeginBlocker` prunes every expired grant on every block, with no limit on how many it processes in one pass. An attacker can create a large number of short-lived grants that all expire around the same time. Once they expire, every following block pays the full cost of pruning that whole backlog, which can grow block processing time without bound.

`x/feegrant` already solved this same problem by capping its own per-block pruning at 200 grants. `x/authz` had no equivalent cap.

### Fix

- Add a `limit` parameter to `DequeueAndDeleteExpiredGrants` in `x/authz/keeper/keeper.go`, stopping the pruning loop once the limit is hit so remaining expired grants are picked up on the next call.
- Update the `BeginBlocker` call site in `x/authz/module/abci.go` to pass a cap of 200, matching `x/feegrant`'s existing constant and rationale.
- Add `TestDequeueAndDeleteExpiredGrantsCapsPerCall`, which creates more expired grants than the cap, confirms only the capped number are pruned in one call, and confirms the remainder are pruned (in queue order) on the next call.

This backports [cosmos/cosmos-sdk#26588](https://github.com/cosmos/cosmos-sdk/pull/26588) to release/v0.54.x.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments